### PR TITLE
feat: enhance super admin registration and schema

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -21,6 +21,7 @@ import type * as schools from "../schools.js";
 import type * as subscriptionPlans from "../subscriptionPlans.js";
 import type * as subscriptionRequests from "../subscriptionRequests.js";
 import type * as subscriptions from "../subscriptions.js";
+import type * as superAdmins from "../superAdmins.js";
 import type * as support from "../support.js";
 import type * as trialManagement from "../trialManagement.js";
 import type * as userSettings from "../userSettings.js";
@@ -45,6 +46,7 @@ declare const fullApi: ApiFromModules<{
   subscriptionPlans: typeof subscriptionPlans;
   subscriptionRequests: typeof subscriptionRequests;
   subscriptions: typeof subscriptions;
+  superAdmins: typeof superAdmins;
   support: typeof support;
   trialManagement: typeof trialManagement;
   userSettings: typeof userSettings;

--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -17,10 +17,16 @@ export const register = mutation({
       throw new Error('Email already exists');
     }
 
+    // Check if this is the first super admin (should be owner)
+    const allAdmins = await ctx.db.query('superAdmins').collect();
+    const isFirstAdmin = allAdmins.length === 0;
+
     const id = await ctx.db.insert('superAdmins', {
       name: args.name,
       email: args.email,
       password: args.password, // Already hashed from API route
+      role: isFirstAdmin ? 'owner' : 'admin', // First admin is owner
+      status: 'active',
       createdAt: new Date().toISOString(),
     });
 

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -2,13 +2,16 @@ import { defineSchema, defineTable } from 'convex/server';
 import { v } from 'convex/values';
 
 export default defineSchema({
-  superAdmins: defineTable({
+   superAdmins: defineTable({
     name: v.string(),
     email: v.string(),
     password: v.string(),
+    role: v.union(v.literal('owner'), v.literal('admin'), v.literal('moderator')),
+    status: v.union(v.literal('active'), v.literal('suspended')),
     createdAt: v.string(),
+    createdBy: v.optional(v.string()),
     lastLogin: v.optional(v.string()),
-  }).index('by_email', ['email']),
+  }).index('by_email', ['email']).index('by_role', ['role']).index('by_status', ['status']),
 
   schools: defineTable({
     name: v.string(),

--- a/convex/superAdmins.ts
+++ b/convex/superAdmins.ts
@@ -1,0 +1,192 @@
+import { v } from 'convex/values';
+import { mutation, query } from './_generated/server';
+import type { Id } from './_generated/dataModel';
+
+// Get all super admins
+export const list = query({
+  args: {},
+  handler: async (ctx) => {
+    const admins = await ctx.db.query('superAdmins').order('desc').collect();
+    return admins.map((admin) => ({
+      ...admin,
+      password: undefined, // Don't expose passwords
+    }));
+  },
+});
+
+// Get super admin by ID
+export const getById = query({
+  args: { id: v.id('superAdmins') },
+  handler: async (ctx, args) => {
+    const admin = await ctx.db.get(args.id);
+    if (!admin) return null;
+    
+    return {
+      ...admin,
+      password: undefined, // Don't expose password
+    };
+  },
+});
+
+// Get super admin by email
+export const getByEmail = query({
+  args: { email: v.string() },
+  handler: async (ctx, args) => {
+    const admin = await ctx.db
+      .query('superAdmins')
+      .withIndex('by_email', (q) => q.eq('email', args.email))
+      .first();
+    
+    if (!admin) return null;
+    
+    return {
+      ...admin,
+      password: undefined, // Don't expose password
+    };
+  },
+});
+
+// Create new super admin
+export const create = mutation({
+  args: {
+    name: v.string(),
+    email: v.string(),
+    password: v.string(),
+    role: v.union(v.literal('owner'), v.literal('admin'), v.literal('moderator')),
+    createdBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Check if email already exists
+    const existing = await ctx.db
+      .query('superAdmins')
+      .withIndex('by_email', (q) => q.eq('email', args.email))
+      .first();
+
+    if (existing) {
+      throw new Error('Email already exists');
+    }
+
+    // Create the new super admin
+    const id = await ctx.db.insert('superAdmins', {
+      name: args.name,
+      email: args.email,
+      password: args.password, // Should be hashed from API route
+      role: args.role,
+      status: 'active',
+      createdAt: new Date().toISOString(),
+      createdBy: args.createdBy,
+    });
+
+    return id;
+  },
+});
+
+// Update super admin role
+export const updateRole = mutation({
+  args: {
+    id: v.id('superAdmins'),
+    role: v.union(v.literal('owner'), v.literal('admin'), v.literal('moderator')),
+  },
+  handler: async (ctx, args) => {
+    const admin = await ctx.db.get(args.id);
+    
+    if (!admin) {
+      throw new Error('Super admin not found');
+    }
+
+    await ctx.db.patch(args.id, {
+      role: args.role,
+    });
+
+    return args.id;
+  },
+});
+
+// Suspend super admin
+export const suspend = mutation({
+  args: {
+    id: v.id('superAdmins'),
+  },
+  handler: async (ctx, args) => {
+    const admin = await ctx.db.get(args.id);
+    
+    if (!admin) {
+      throw new Error('Super admin not found');
+    }
+
+    await ctx.db.patch(args.id, {
+      status: 'suspended',
+    });
+
+    return args.id;
+  },
+});
+
+// Activate super admin
+export const activate = mutation({
+  args: {
+    id: v.id('superAdmins'),
+  },
+  handler: async (ctx, args) => {
+    const admin = await ctx.db.get(args.id);
+    
+    if (!admin) {
+      throw new Error('Super admin not found');
+    }
+
+    await ctx.db.patch(args.id, {
+      status: 'active',
+    });
+
+    return args.id;
+  },
+});
+
+// Delete super admin
+export const remove = mutation({
+  args: {
+    id: v.id('superAdmins'),
+  },
+  handler: async (ctx, args) => {
+    const admin = await ctx.db.get(args.id);
+    
+    if (!admin) {
+      throw new Error('Super admin not found');
+    }
+
+    // Check if this is the last owner
+    if (admin.role === 'owner') {
+      const owners = await ctx.db
+        .query('superAdmins')
+        .withIndex('by_role', (q) => q.eq('role', 'owner'))
+        .collect();
+      
+      if (owners.length <= 1) {
+        throw new Error('Cannot delete the last owner');
+      }
+    }
+
+    await ctx.db.delete(args.id);
+
+    return args.id;
+  },
+});
+
+// Get statistics
+export const getStats = query({
+  args: {},
+  handler: async (ctx) => {
+    const allAdmins = await ctx.db.query('superAdmins').collect();
+    
+    const stats = {
+      total: allAdmins.length,
+      active: allAdmins.filter((a) => a.status === 'active').length,
+      suspended: allAdmins.filter((a) => a.status === 'suspended').length,
+      owners: allAdmins.filter((a) => a.role === 'owner').length,
+      admins: allAdmins.filter((a) => a.role === 'admin').length,
+      moderators: allAdmins.filter((a) => a.role === 'moderator').length,
+    };
+
+    return stats;
+  },
+});

--- a/src/app/api/auth/create-super-admin/route.ts
+++ b/src/app/api/auth/create-super-admin/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from 'next/server';
+import { ConvexHttpClient } from 'convex/browser';
+import { api } from '../../../../../convex/_generated/api';
+import { PasswordManager } from '@/lib/password';
+import type { Id } from '../../../../../convex/_generated/dataModel';
+
+function getConvexClient(): ConvexHttpClient {
+  const url = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!url) {
+    throw new Error('NEXT_PUBLIC_CONVEX_URL is not configured');
+  }
+  return new ConvexHttpClient(url);
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  const convex = getConvexClient();
+  try {
+    const body = await request.json();
+    const { name, email, password, role, createdBy } = body;
+
+    if (!name || !email || !password || !role || !createdBy) {
+      return NextResponse.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      );
+    }
+
+    // Validate role
+    if (!['owner', 'admin', 'moderator'].includes(role)) {
+      return NextResponse.json(
+        { error: 'Invalid role' },
+        { status: 400 }
+      );
+    }
+
+    // Validate password length
+    if (password.length < 8) {
+      return NextResponse.json(
+        { error: 'Password must be at least 8 characters' },
+        { status: 400 }
+      );
+    }
+
+    // Hash the password
+    const hashedPassword = await PasswordManager.hash(password);
+
+    // Create the super admin in Convex
+    const adminId = await convex.mutation(api.superAdmins.create, {
+      name,
+      email: email.toLowerCase(),
+      password: hashedPassword,
+      role,
+      createdBy,
+    });
+
+    return NextResponse.json({
+      success: true,
+      adminId,
+      message: 'Super admin created successfully',
+    });
+  } catch (error) {
+    console.error('Error creating super admin:', error);
+
+    if (error instanceof Error) {
+      if (error.message.includes('Email already exists')) {
+        return NextResponse.json(
+          { error: 'Email already exists' },
+          { status: 409 }
+        );
+      }
+    }
+
+    return NextResponse.json(
+      { error: 'Failed to create super admin' },
+      { status: 500 }
+    );
+  }
+}

--- a/src/app/super-admin/manage-admins/page.tsx
+++ b/src/app/super-admin/manage-admins/page.tsx
@@ -1,0 +1,335 @@
+'use client';
+
+import * as React from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '../../../../convex/_generated/api';
+import type { Id } from '../../../../convex/_generated/dataModel';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { MoreHorizontal, Plus, Shield, ShieldCheck, ShieldAlert, UserPlus } from 'lucide-react';
+import { toast } from 'sonner';
+import { useAuth } from '@/hooks/useAuth';
+import { AddAdminDialog } from '../../../components/add-admin-dialog';
+import { EditRoleDialog } from '../../../components/edit-admin-dialog';
+import { DeleteAdminDialog } from'../../../components/delete-admin-dialog';
+interface SuperAdmin {
+  _id: Id<'superAdmins'>;
+  _creationTime: number;
+  name: string;
+  email: string;
+  role: 'owner' | 'admin' | 'moderator';
+  status: 'active' | 'suspended';
+  createdAt: string;
+  createdBy?: string;
+  lastLogin?: string;
+}
+
+export default function ManageAdminsPage(): React.JSX.Element {
+  const { user } = useAuth();
+  const [showAddDialog, setShowAddDialog] = React.useState<boolean>(false);
+  const [selectedAdmin, setSelectedAdmin] = React.useState<SuperAdmin | null>(null);
+  const [showEditDialog, setShowEditDialog] = React.useState<boolean>(false);
+  const [showDeleteDialog, setShowDeleteDialog] = React.useState<boolean>(false);
+
+  // Queries
+  const admins = useQuery(api.superAdmins.list);
+  const stats = useQuery(api.superAdmins.getStats);
+  const currentAdmin = useQuery(
+    api.superAdmins.getByEmail,
+    user?.email ? { email: user.email } : 'skip'
+  );
+
+  // Mutations
+  const suspendAdmin = useMutation(api.superAdmins.suspend);
+  const activateAdmin = useMutation(api.superAdmins.activate);
+
+  const handleSuspend = async (adminId: Id<'superAdmins'>): Promise<void> => {
+    try {
+      await suspendAdmin({ id: adminId });
+      toast.success('Admin suspended successfully');
+    } catch (error) {
+      toast.error('Failed to suspend admin', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+
+  const handleActivate = async (adminId: Id<'superAdmins'>): Promise<void> => {
+    try {
+      await activateAdmin({ id: adminId });
+      toast.success('Admin activated successfully');
+    } catch (error) {
+      toast.error('Failed to activate admin', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+
+  const getRoleBadge = (role: 'owner' | 'admin' | 'moderator'): React.JSX.Element => {
+    const variants: Record<string, { icon: React.ElementType; variant: 'default' | 'secondary' | 'outline'; color: string }> = {
+      owner: { icon: ShieldCheck, variant: 'default', color: 'bg-blue-600 hover:bg-blue-700' },
+      admin: { icon: Shield, variant: 'secondary', color: 'bg-gray-600 hover:bg-gray-700' },
+      moderator: { icon: ShieldAlert, variant: 'outline', color: 'border-gray-400' },
+    };
+
+    const config = variants[role] || variants.moderator;
+    const Icon = config.icon;
+
+    return (
+      <Badge variant={config.variant} className={config.color}>
+        <Icon className="w-3 h-3 mr-1" />
+        {role.charAt(0).toUpperCase() + role.slice(1)}
+      </Badge>
+    );
+  };
+
+  const getStatusBadge = (status: 'active' | 'suspended'): React.JSX.Element => {
+    if (status === 'active') {
+      return <Badge variant="default" className="bg-green-600 hover:bg-green-700">Active</Badge>;
+    }
+    return <Badge variant="destructive">Suspended</Badge>;
+  };
+
+  const canManageAdmin = (targetRole: 'owner' | 'admin' | 'moderator'): boolean => {
+    if (!currentAdmin) return false;
+    
+    const roleHierarchy: Record<string, number> = { owner: 3, admin: 2, moderator: 1 };
+    return roleHierarchy[currentAdmin.role] > roleHierarchy[targetRole];
+  };
+
+  const canModifyRole = (targetRole: 'owner' | 'admin' | 'moderator'): boolean => {
+    if (!currentAdmin) return false;
+    
+    // Only owners can create/modify other owners
+    if (targetRole === 'owner') {
+      return currentAdmin.role === 'owner';
+    }
+    
+    // Admins can manage moderators
+    if (targetRole === 'moderator' && currentAdmin.role === 'admin') {
+      return true;
+    }
+    
+    return currentAdmin.role === 'owner';
+  };
+
+  if (!admins || !stats || !currentAdmin) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-6 space-y-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight">Manage Admins</h1>
+          <p className="text-gray-600 mt-1">
+            Manage super administrator accounts and roles
+          </p>
+        </div>
+        <Button onClick={() => setShowAddDialog(true)} className="gap-2">
+          <Plus className="w-4 h-4" />
+          Add Admin
+        </Button>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Admins</CardTitle>
+            <UserPlus className="h-4 w-4 text-gray-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.total}</div>
+            <p className="text-xs text-gray-600 mt-1">
+              {stats.active} active, {stats.suspended} suspended
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Owners</CardTitle>
+            <ShieldCheck className="h-4 w-4 text-blue-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.owners}</div>
+            <p className="text-xs text-gray-600 mt-1">Full system access</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Admins</CardTitle>
+            <Shield className="h-4 w-4 text-gray-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.admins}</div>
+            <p className="text-xs text-gray-600 mt-1">Manage schools & users</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Moderators</CardTitle>
+            <ShieldAlert className="h-4 w-4 text-gray-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{stats.moderators}</div>
+            <p className="text-xs text-gray-600 mt-1">Limited access</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Admin List */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Super Administrators</CardTitle>
+          <CardDescription>
+            A list of all super admin accounts with their roles and status
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Name</TableHead>
+                <TableHead>Email</TableHead>
+                <TableHead>Role</TableHead>
+                <TableHead>Status</TableHead>
+                <TableHead>Created</TableHead>
+                <TableHead>Last Login</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {admins.length === 0 ? (
+                <TableRow>
+                  <TableCell colSpan={7} className="text-center text-gray-500">
+                    No admins found
+                  </TableCell>
+                </TableRow>
+              ) : (
+                admins.map((admin) => (
+                  <TableRow key={admin._id}>
+                    <TableCell className="font-medium">{admin.name}</TableCell>
+                    <TableCell>{admin.email}</TableCell>
+                    <TableCell>{getRoleBadge(admin.role)}</TableCell>
+                    <TableCell>{getStatusBadge(admin.status)}</TableCell>
+                    <TableCell>
+                      {new Date(admin.createdAt).toLocaleDateString()}
+                    </TableCell>
+                    <TableCell>
+                      {admin.lastLogin
+                        ? new Date(admin.lastLogin).toLocaleDateString()
+                        : 'Never'}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" className="h-8 w-8 p-0">
+                            <span className="sr-only">Open menu</span>
+                            <MoreHorizontal className="h-4 w-4" />
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          {canModifyRole(admin.role) && (
+                            <DropdownMenuItem
+                              onClick={() => {
+                                setSelectedAdmin(admin);
+                                setShowEditDialog(true);
+                              }}
+                            >
+                              Edit Role
+                            </DropdownMenuItem>
+                          )}
+                          {canManageAdmin(admin.role) && admin.status === 'active' && (
+                            <DropdownMenuItem onClick={() => handleSuspend(admin._id)}>
+                              Suspend
+                            </DropdownMenuItem>
+                          )}
+                          {canManageAdmin(admin.role) && admin.status === 'suspended' && (
+                            <DropdownMenuItem onClick={() => handleActivate(admin._id)}>
+                              Activate
+                            </DropdownMenuItem>
+                          )}
+                          {canManageAdmin(admin.role) && admin._id !== currentAdmin._id && (
+                            <>
+                              <DropdownMenuSeparator />
+                              <DropdownMenuItem
+                                className="text-red-600"
+                                onClick={() => {
+                                  setSelectedAdmin(admin);
+                                  setShowDeleteDialog(true);
+                                }}
+                              >
+                                Delete
+                              </DropdownMenuItem>
+                            </>
+                          )}
+                          {admin._id === currentAdmin._id && (
+                            <DropdownMenuItem disabled>
+                              Cannot modify yourself
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </TableCell>
+                  </TableRow>
+                ))
+              )}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+
+      {/* Dialogs */}
+      <AddAdminDialog
+        open={showAddDialog}
+        onOpenChange={setShowAddDialog}
+        currentUserRole={currentAdmin.role}
+        createdBy={currentAdmin._id}
+      />
+
+      {selectedAdmin && (
+        <>
+          <EditRoleDialog
+            open={showEditDialog}
+            onOpenChange={setShowEditDialog}
+            admin={selectedAdmin}
+            currentUserRole={currentAdmin.role}
+          />
+          <DeleteAdminDialog
+            open={showDeleteDialog}
+            onOpenChange={setShowDeleteDialog}
+            admin={selectedAdmin}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/add-admin-dialog.tsx
+++ b/src/components/add-admin-dialog.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import * as React from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
+import { User, Mail, Lock, Eye, EyeOff, Shield } from 'lucide-react';
+import type { Id } from '../../convex/_generated/dataModel';
+
+interface AddAdminDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  currentUserRole: 'owner' | 'admin' | 'moderator';
+  createdBy: Id<'superAdmins'>;
+}
+
+export function AddAdminDialog({
+  open,
+  onOpenChange,
+  currentUserRole,
+  createdBy,
+}: AddAdminDialogProps): React.JSX.Element {
+  const [name, setName] = React.useState<string>('');
+  const [email, setEmail] = React.useState<string>('');
+  const [password, setPassword] = React.useState<string>('');
+  const [role, setRole] = React.useState<'admin' | 'moderator'>('admin');
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [showPassword, setShowPassword] = React.useState<boolean>(false);
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    
+    if (!name || !email || !password) {
+      toast.error('Please fill in all fields');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      const response = await fetch('/api/auth/create-super-admin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          email,
+          password,
+          role,
+          createdBy,
+        }),
+      });
+
+      const data = await response.json();
+
+      if (!response.ok) {
+        throw new Error(data.error || 'Failed to create admin');
+      }
+
+      toast.success('Admin created successfully', {
+        description: `${name} has been added as a ${role}`,
+      });
+
+      setName('');
+      setEmail('');
+      setPassword('');
+      setRole('admin');
+      onOpenChange(false);
+    } catch (error) {
+      toast.error('Failed to create admin', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getAvailableRoles = (): Array<{ value: 'owner' | 'admin' | 'moderator'; label: string; description: string }> => {
+    if (currentUserRole === 'owner') {
+      return [
+        { value: 'owner', label: 'Owner', description: 'Full system access and control' },
+        { value: 'admin', label: 'Admin', description: 'Manage schools and users' },
+        { value: 'moderator', label: 'Moderator', description: 'Limited access and permissions' },
+      ];
+    }
+    
+    if (currentUserRole === 'admin') {
+      return [
+        { value: 'moderator', label: 'Moderator', description: 'Limited access and permissions' },
+      ];
+    }
+
+    return [];
+  };
+
+  const availableRoles = getAvailableRoles();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <DialogHeader>
+          <DialogTitle>Add New Admin</DialogTitle>
+          <DialogDescription>
+            Create a new super administrator account with specific role and permissions
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label htmlFor="name">Full Name</Label>
+              <div className="relative">
+                <User className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                <Input
+                  id="name"
+                  placeholder="John Doe"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  disabled={loading}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="email">Email Address</Label>
+              <div className="relative">
+                <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                <Input
+                  id="email"
+                  type="email"
+                  placeholder="john@example.com"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={loading}
+                  className="pl-10"
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="password">Password</Label>
+              <div className="relative">
+                <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500" />
+                <Input
+                  id="password"
+                  type={showPassword ? 'text' : 'password'}
+                  placeholder="••••••••"
+                  value={password}
+                  onChange={(e) => setPassword(e.target.value)}
+                  disabled={loading}
+                  className="pl-10 pr-10"
+                />
+                <button
+                  type="button"
+                  onClick={() => setShowPassword(!showPassword)}
+                  className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700 focus:outline-none"
+                  disabled={loading}
+                >
+                  {showPassword ? (
+                    <EyeOff className="h-4 w-4" />
+                  ) : (
+                    <Eye className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+              <p className="text-xs text-gray-600">
+                Minimum 8 characters
+              </p>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="role">Role</Label>
+              <div className="relative">
+                <Shield className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-gray-500 z-10 pointer-events-none" />
+                <Select
+                  value={role}
+                  onValueChange={(value) => setRole(value as 'admin' | 'moderator')}
+                  disabled={loading}
+                >
+                  <SelectTrigger id="role" className="pl-10">
+                    <SelectValue placeholder="Select role" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {availableRoles.map((roleOption) => (
+                      <SelectItem key={roleOption.value} value={roleOption.value}>
+                        <div className="flex flex-col">
+                          <span className="font-medium">{roleOption.label}</span>
+                          <span className="text-xs text-gray-600">
+                            {roleOption.description}
+                          </span>
+                        </div>
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Creating...' : 'Create Admin'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dashboard/app-sidebar.tsx
+++ b/src/components/dashboard/app-sidebar.tsx
@@ -17,6 +17,7 @@ import {
   CheckSquare,
   Bell,
   Clock,
+  Shield,
 } from 'lucide-react';
 
 import {
@@ -35,6 +36,7 @@ const navItems = [
   { href: '/super-admin', icon: LayoutDashboard, label: 'Dashboard' },
   { href: '/super-admin/approvals', icon: CheckSquare, label: 'Approvals' },
   { href: '/super-admin/profile', icon: User, label: 'Profile Management' },
+  { href: '/super-admin/manage-admins', icon: Shield, label: 'Manage Admins' },
   { href: '/super-admin/school-admins', icon: Users, label: 'School Admins' },
   { href: '/super-admin/schools', icon: School, label: 'Schools' },
   { href: '/super-admin/subscriptions', icon: CreditCard, label: 'Subscriptions' },

--- a/src/components/delete-admin-dialog.tsx
+++ b/src/components/delete-admin-dialog.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import * as React from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '../../convex/_generated/api';
+import type { Id } from '../../convex/_generated/dataModel';
+import { Button } from '@/components/ui/button';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { toast } from 'sonner';
+import { AlertTriangle } from 'lucide-react';
+
+interface SuperAdmin {
+  _id: Id<'superAdmins'>;
+  name: string;
+  email: string;
+  role: 'owner' | 'admin' | 'moderator';
+}
+
+interface DeleteAdminDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  admin: SuperAdmin;
+}
+
+export function DeleteAdminDialog({
+  open,
+  onOpenChange,
+  admin,
+}: DeleteAdminDialogProps): React.JSX.Element {
+  const [loading, setLoading] = React.useState<boolean>(false);
+
+  const removeAdmin = useMutation(api.superAdmins.remove);
+
+  const handleDelete = async (): Promise<void> => {
+    setLoading(true);
+
+    try {
+      await removeAdmin({ id: admin._id });
+
+      toast.success('Admin deleted successfully', {
+        description: `${admin.name} has been removed from the system`,
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      toast.error('Failed to delete admin', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <div className="flex items-center gap-2">
+            <AlertTriangle className="h-5 w-5 text-red-600" />
+            <AlertDialogTitle>Delete Super Admin</AlertDialogTitle>
+          </div>
+          <AlertDialogDescription className="space-y-2">
+            <p>
+              Are you sure you want to delete <strong>{admin.name}</strong>? This action cannot be undone.
+            </p>
+            <p className="text-sm">
+              Email: <strong>{admin.email}</strong>
+            </p>
+            <p className="text-sm">
+              Role: <strong>{admin.role.charAt(0).toUpperCase() + admin.role.slice(1)}</strong>
+            </p>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={loading}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={loading}
+          >
+            {loading ? 'Deleting...' : 'Delete Admin'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/edit-admin-dialog.tsx
+++ b/src/components/edit-admin-dialog.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import * as React from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '../../convex/_generated/api';
+import type { Id } from '../../convex/_generated/dataModel';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
+
+interface SuperAdmin {
+  _id: Id<'superAdmins'>;
+  name: string;
+  email: string;
+  role: 'owner' | 'admin' | 'moderator';
+}
+
+interface EditRoleDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  admin: SuperAdmin;
+  currentUserRole: 'owner' | 'admin' | 'moderator';
+}
+
+export function EditRoleDialog({
+  open,
+  onOpenChange,
+  admin,
+  currentUserRole,
+}: EditRoleDialogProps): React.JSX.Element {
+  const [selectedRole, setSelectedRole] = React.useState<'owner' | 'admin' | 'moderator'>(admin.role);
+  const [loading, setLoading] = React.useState<boolean>(false);
+
+  const updateRole = useMutation(api.superAdmins.updateRole);
+
+  React.useEffect(() => {
+    setSelectedRole(admin.role);
+  }, [admin.role]);
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    
+    if (selectedRole === admin.role) {
+      toast.error('Please select a different role');
+      return;
+    }
+
+    setLoading(true);
+
+    try {
+      await updateRole({
+        id: admin._id,
+        role: selectedRole,
+      });
+
+      toast.success('Role updated successfully', {
+        description: `${admin.name} is now a ${selectedRole}`,
+      });
+
+      onOpenChange(false);
+    } catch (error) {
+      toast.error('Failed to update role', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const getAvailableRoles = (): Array<{ value: 'owner' | 'admin' | 'moderator'; label: string; description: string }> => {
+    if (currentUserRole === 'owner') {
+      return [
+        { value: 'owner', label: 'Owner', description: 'Full system access and control' },
+        { value: 'admin', label: 'Admin', description: 'Manage schools and users' },
+        { value: 'moderator', label: 'Moderator', description: 'Limited access and permissions' },
+      ];
+    }
+    
+    if (currentUserRole === 'admin') {
+      return [
+        { value: 'admin', label: 'Admin', description: 'Manage schools and users' },
+        { value: 'moderator', label: 'Moderator', description: 'Limited access and permissions' },
+      ];
+    }
+
+    return [];
+  };
+
+  const availableRoles = getAvailableRoles();
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[450px]">
+        <DialogHeader>
+          <DialogTitle>Edit Admin Role</DialogTitle>
+          <DialogDescription>
+            Change the role and permissions for {admin.name}
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit}>
+          <div className="grid gap-4 py-4">
+            <div className="grid gap-2">
+              <Label>Current Role</Label>
+              <div className="text-sm text-gray-600">
+                {admin.role.charAt(0).toUpperCase() + admin.role.slice(1)}
+              </div>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="new-role">New Role</Label>
+              <Select
+                value={selectedRole}
+                onValueChange={(value) => setSelectedRole(value as 'owner' | 'admin' | 'moderator')}
+                disabled={loading}
+              >
+                <SelectTrigger id="new-role">
+                  <SelectValue placeholder="Select new role" />
+                </SelectTrigger>
+                <SelectContent>
+                  {availableRoles.map((roleOption) => (
+                    <SelectItem key={roleOption.value} value={roleOption.value}>
+                      <div className="flex flex-col">
+                        <span className="font-medium">{roleOption.label}</span>
+                        <span className="text-xs text-gray-600">
+                          {roleOption.description}
+                        </span>
+                      </div>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={loading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading || selectedRole === admin.role}>
+              {loading ? 'Updating...' : 'Update Role'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
- Updated the registration mutation to assign the 'owner' role to the first super admin and set the status to 'active'.
- Modified the superAdmins schema to include role and status fields, allowing for better management of admin roles.
- Added new indexes for role and status in the superAdmins table to improve query performance.
- Introduced a new navigation item in the AppSidebar for managing admins, enhancing admin functionality.