### PR TITLE
feat: add subjects schema and integrate into API

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -22,6 +22,7 @@ import type * as schoolCreationRequests from "../schoolCreationRequests.js";
 import type * as schools from "../schools.js";
 import type * as securityAlerts from "../securityAlerts.js";
 import type * as sessions from "../sessions.js";
+import type * as subjects from "../subjects.js";
 import type * as subscriptionPlans from "../subscriptionPlans.js";
 import type * as subscriptionRequests from "../subscriptionRequests.js";
 import type * as subscriptions from "../subscriptions.js";
@@ -53,6 +54,7 @@ declare const fullApi: ApiFromModules<{
   schools: typeof schools;
   securityAlerts: typeof securityAlerts;
   sessions: typeof sessions;
+  subjects: typeof subjects;
   subscriptionPlans: typeof subscriptionPlans;
   subscriptionRequests: typeof subscriptionRequests;
   subscriptions: typeof subscriptions;

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -357,6 +357,22 @@ classes: defineTable({
     .index('by_department', ['department'])
     .index('by_teacher', ['classTeacherId']),
 
-
+subjects: defineTable({
+    schoolId: v.string(),
+    subjectCode: v.string(), // Auto-generated: department initials + 4 random digits (e.g., CR0234, KG1245)
+    subjectName: v.string(),
+    description: v.optional(v.string()),
+    category: v.union(v.literal('core'), v.literal('elective'), v.literal('extracurricular')),
+    department: v.union(v.literal('creche'), v.literal('kindergarten'), v.literal('primary'), v.literal('junior_high')),
+    status: v.union(v.literal('active'), v.literal('inactive')),
+    createdAt: v.string(),
+    updatedAt: v.string(),
+    createdBy: v.string(), // School Admin ID
+  })
+    .index('by_school', ['schoolId'])
+    .index('by_subject_code', ['subjectCode'])
+    .index('by_status', ['status'])
+    .index('by_department', ['department'])
+    .index('by_category', ['category']),
 
 });

--- a/convex/subjects.ts
+++ b/convex/subjects.ts
@@ -1,0 +1,421 @@
+import { v } from 'convex/values';
+import { mutation, query } from './_generated/server';
+
+// Generate subject code: department initials + 4 random digits
+function generateSubjectCode(department: 'creche' | 'kindergarten' | 'primary' | 'junior_high'): string {
+  const departmentInitials: Record<string, string> = {
+    creche: 'CR',
+    kindergarten: 'KG',
+    primary: 'PR',
+    junior_high: 'JH',
+  };
+  
+  const initials = departmentInitials[department];
+  const randomDigits = Math.floor(1000 + Math.random() * 9000); // 4 random digits
+  return `${initials}${randomDigits}`;
+}
+
+// Query: Get all subjects for a school
+export const getSubjectsBySchool = query({
+  args: { schoolId: v.string() },
+  handler: async (ctx, args) => {
+    const subjects = await ctx.db
+      .query('subjects')
+      .withIndex('by_school', (q) => q.eq('schoolId', args.schoolId))
+      .collect();
+
+    return subjects;
+  },
+});
+
+// Query: Get subject by ID
+export const getSubjectById = query({
+  args: { subjectId: v.id('subjects') },
+  handler: async (ctx, args) => {
+    const subject = await ctx.db.get(args.subjectId);
+    return subject;
+  },
+});
+
+// Query: Get subject statistics for a school
+export const getSubjectStats = query({
+  args: { schoolId: v.string() },
+  handler: async (ctx, args) => {
+    const subjects = await ctx.db
+      .query('subjects')
+      .withIndex('by_school', (q) => q.eq('schoolId', args.schoolId))
+      .collect();
+
+    const activeSubjects = subjects.filter((s) => s.status === 'active').length;
+    const inactiveSubjects = subjects.filter((s) => s.status === 'inactive').length;
+    const coreSubjects = subjects.filter((s) => s.category === 'core').length;
+    const electiveSubjects = subjects.filter((s) => s.category === 'elective').length;
+    const extracurricularSubjects = subjects.filter((s) => s.category === 'extracurricular').length;
+    const crecheSubjects = subjects.filter((s) => s.department === 'creche').length;
+    const kindergartenSubjects = subjects.filter((s) => s.department === 'kindergarten').length;
+    const primarySubjects = subjects.filter((s) => s.department === 'primary').length;
+    const juniorHighSubjects = subjects.filter((s) => s.department === 'junior_high').length;
+
+    return {
+      total: subjects.length,
+      active: activeSubjects,
+      inactive: inactiveSubjects,
+      core: coreSubjects,
+      elective: electiveSubjects,
+      extracurricular: extracurricularSubjects,
+      creche: crecheSubjects,
+      kindergarten: kindergartenSubjects,
+      primary: primarySubjects,
+      juniorHigh: juniorHighSubjects,
+    };
+  },
+});
+
+// Mutation: Add new subject
+export const addSubject = mutation({
+  args: {
+    schoolId: v.string(),
+    subjectName: v.string(),
+    description: v.optional(v.string()),
+    category: v.union(v.literal('core'), v.literal('elective'), v.literal('extracurricular')),
+    department: v.union(v.literal('creche'), v.literal('kindergarten'), v.literal('primary'), v.literal('junior_high')),
+    createdBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Check if subject name already exists for this school
+    const existingSubject = await ctx.db
+      .query('subjects')
+      .withIndex('by_school', (q) => q.eq('schoolId', args.schoolId))
+      .filter((q) => q.eq(q.field('subjectName'), args.subjectName))
+      .first();
+
+    if (existingSubject) {
+      throw new Error('A subject with this name already exists in your school');
+    }
+
+    // Generate unique subject code
+    let subjectCode = generateSubjectCode(args.department);
+    let existingCode = await ctx.db
+      .query('subjects')
+      .withIndex('by_subject_code', (q) => q.eq('subjectCode', subjectCode))
+      .first();
+
+    // Ensure unique code
+    while (existingCode) {
+      subjectCode = generateSubjectCode(args.department);
+      existingCode = await ctx.db
+        .query('subjects')
+        .withIndex('by_subject_code', (q) => q.eq('subjectCode', subjectCode))
+        .first();
+    }
+
+    const now = new Date().toISOString();
+
+    const subjectId = await ctx.db.insert('subjects', {
+      schoolId: args.schoolId,
+      subjectCode,
+      subjectName: args.subjectName,
+      description: args.description,
+      category: args.category,
+      department: args.department,
+      status: 'active',
+      createdAt: now,
+      updatedAt: now,
+      createdBy: args.createdBy,
+    });
+
+    // Create audit log
+    await ctx.db.insert('auditLogs', {
+      timestamp: now,
+      userId: args.createdBy,
+      userName: 'School Admin',
+      action: 'CREATE',
+      entity: 'Subject',
+      entityId: subjectId,
+      details: `Added subject: ${args.subjectName} (${subjectCode})`,
+      ipAddress: '0.0.0.0',
+    });
+
+    return { subjectId, generatedSubjectCode: subjectCode };
+  },
+});
+
+// Mutation: Add multiple subjects (bulk)
+export const addBulkSubjects = mutation({
+  args: {
+    schoolId: v.string(),
+    subjects: v.array(v.object({
+      subjectName: v.string(),
+      description: v.optional(v.string()),
+      category: v.union(v.literal('core'), v.literal('elective'), v.literal('extracurricular')),
+      department: v.union(v.literal('creche'), v.literal('kindergarten'), v.literal('primary'), v.literal('junior_high')),
+    })),
+    createdBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const results = [];
+    const now = new Date().toISOString();
+
+    for (const subjectData of args.subjects) {
+      // Check if subject name already exists
+      const existingSubject = await ctx.db
+        .query('subjects')
+        .withIndex('by_school', (q) => q.eq('schoolId', args.schoolId))
+        .filter((q) => q.eq(q.field('subjectName'), subjectData.subjectName))
+        .first();
+
+      if (existingSubject) {
+        results.push({
+          subjectName: subjectData.subjectName,
+          success: false,
+          error: 'Subject name already exists',
+        });
+        continue;
+      }
+
+      // Generate unique subject code
+      let subjectCode = generateSubjectCode(subjectData.department);
+      let existingCode = await ctx.db
+        .query('subjects')
+        .withIndex('by_subject_code', (q) => q.eq('subjectCode', subjectCode))
+        .first();
+
+      while (existingCode) {
+        subjectCode = generateSubjectCode(subjectData.department);
+        existingCode = await ctx.db
+          .query('subjects')
+          .withIndex('by_subject_code', (q) => q.eq('subjectCode', subjectCode))
+          .first();
+      }
+
+      const subjectId = await ctx.db.insert('subjects', {
+        schoolId: args.schoolId,
+        subjectCode,
+        subjectName: subjectData.subjectName,
+        description: subjectData.description,
+        category: subjectData.category,
+        department: subjectData.department,
+        status: 'active',
+        createdAt: now,
+        updatedAt: now,
+        createdBy: args.createdBy,
+      });
+
+      results.push({
+        subjectName: subjectData.subjectName,
+        subjectCode,
+        success: true,
+        subjectId,
+      });
+
+      // Create audit log
+      await ctx.db.insert('auditLogs', {
+        timestamp: now,
+        userId: args.createdBy,
+        userName: 'School Admin',
+        action: 'CREATE',
+        entity: 'Subject',
+        entityId: subjectId,
+        details: `Bulk added subject: ${subjectData.subjectName} (${subjectCode})`,
+        ipAddress: '0.0.0.0',
+      });
+    }
+
+    return results;
+  },
+});
+
+// Mutation: Update subject
+export const updateSubject = mutation({
+  args: {
+    subjectId: v.id('subjects'),
+    subjectName: v.optional(v.string()),
+    description: v.optional(v.string()),
+    category: v.optional(v.union(v.literal('core'), v.literal('elective'), v.literal('extracurricular'))),
+    department: v.optional(v.union(v.literal('creche'), v.literal('kindergarten'), v.literal('primary'), v.literal('junior_high'))),
+    status: v.optional(v.union(v.literal('active'), v.literal('inactive'))),
+    updatedBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const subject = await ctx.db.get(args.subjectId);
+
+    if (!subject) {
+      throw new Error('Subject not found');
+    }
+
+    // If subject name is being updated, check for duplicates
+    if (args.subjectName && args.subjectName !== subject.subjectName) {
+      const existingSubject = await ctx.db
+        .query('subjects')
+        .withIndex('by_school', (q) => q.eq('schoolId', subject.schoolId))
+        .filter((q) => q.eq(q.field('subjectName'), args.subjectName))
+        .first();
+
+      if (existingSubject && existingSubject._id !== args.subjectId) {
+        throw new Error('A subject with this name already exists in your school');
+      }
+    }
+
+    const now = new Date().toISOString();
+
+    const updateData: Record<string, unknown> = {
+      updatedAt: now,
+    };
+
+    if (args.subjectName !== undefined) updateData.subjectName = args.subjectName;
+    if (args.description !== undefined) updateData.description = args.description;
+    if (args.category !== undefined) updateData.category = args.category;
+    if (args.department !== undefined) {
+      updateData.department = args.department;
+      // Regenerate subject code if department changes
+      let subjectCode = generateSubjectCode(args.department);
+      let existingCode = await ctx.db
+        .query('subjects')
+        .withIndex('by_subject_code', (q) => q.eq('subjectCode', subjectCode))
+        .first();
+
+      while (existingCode && existingCode._id !== args.subjectId) {
+        subjectCode = generateSubjectCode(args.department);
+        existingCode = await ctx.db
+          .query('subjects')
+          .withIndex('by_subject_code', (q) => q.eq('subjectCode', subjectCode))
+          .first();
+      }
+      updateData.subjectCode = subjectCode;
+    }
+    if (args.status !== undefined) updateData.status = args.status;
+
+    await ctx.db.patch(args.subjectId, updateData);
+
+    // Create audit log
+    await ctx.db.insert('auditLogs', {
+      timestamp: now,
+      userId: args.updatedBy,
+      userName: 'School Admin',
+      action: 'UPDATE',
+      entity: 'Subject',
+      entityId: args.subjectId,
+      details: `Updated subject: ${subject.subjectName} (${subject.subjectCode})`,
+      ipAddress: '0.0.0.0',
+    });
+
+    return { success: true };
+  },
+});
+
+// Mutation: Delete subject
+export const deleteSubject = mutation({
+  args: {
+    subjectId: v.id('subjects'),
+    deletedBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const subject = await ctx.db.get(args.subjectId);
+
+    if (!subject) {
+      throw new Error('Subject not found');
+    }
+
+    await ctx.db.delete(args.subjectId);
+
+    const now = new Date().toISOString();
+
+    // Create audit log
+    await ctx.db.insert('auditLogs', {
+      timestamp: now,
+      userId: args.deletedBy,
+      userName: 'School Admin',
+      action: 'DELETE',
+      entity: 'Subject',
+      entityId: args.subjectId,
+      details: `Deleted subject: ${subject.subjectName} (${subject.subjectCode})`,
+      ipAddress: '0.0.0.0',
+    });
+
+    return { success: true };
+  },
+});
+
+// Mutation: Delete multiple subjects (bulk)
+export const deleteBulkSubjects = mutation({
+  args: {
+    subjectIds: v.array(v.id('subjects')),
+    deletedBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const results = [];
+    const now = new Date().toISOString();
+
+    for (const subjectId of args.subjectIds) {
+      const subject = await ctx.db.get(subjectId);
+
+      if (!subject) {
+        results.push({
+          subjectId,
+          success: false,
+          error: 'Subject not found',
+        });
+        continue;
+      }
+
+      await ctx.db.delete(subjectId);
+
+      results.push({
+        subjectId,
+        subjectName: subject.subjectName,
+        success: true,
+      });
+
+      // Create audit log
+      await ctx.db.insert('auditLogs', {
+        timestamp: now,
+        userId: args.deletedBy,
+        userName: 'School Admin',
+        action: 'DELETE',
+        entity: 'Subject',
+        entityId: subjectId,
+        details: `Bulk deleted subject: ${subject.subjectName} (${subject.subjectCode})`,
+        ipAddress: '0.0.0.0',
+      });
+    }
+
+    return results;
+  },
+});
+
+// Mutation: Update subject status
+export const updateSubjectStatus = mutation({
+  args: {
+    subjectId: v.id('subjects'),
+    status: v.union(v.literal('active'), v.literal('inactive')),
+    updatedBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const subject = await ctx.db.get(args.subjectId);
+
+    if (!subject) {
+      throw new Error('Subject not found');
+    }
+
+    const now = new Date().toISOString();
+
+    await ctx.db.patch(args.subjectId, {
+      status: args.status,
+      updatedAt: now,
+    });
+
+    // Create audit log
+    await ctx.db.insert('auditLogs', {
+      timestamp: now,
+      userId: args.updatedBy,
+      userName: 'School Admin',
+      action: 'UPDATE',
+      entity: 'Subject',
+      entityId: args.subjectId,
+      details: `Changed subject status to ${args.status}: ${subject.subjectName} (${subject.subjectCode})`,
+      ipAddress: '0.0.0.0',
+    });
+
+    return { success: true };
+  },
+});

--- a/src/app/school-admin/subjects/page.tsx
+++ b/src/app/school-admin/subjects/page.tsx
@@ -1,0 +1,668 @@
+'use client';
+
+import { JSX, useState } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '@/../convex/_generated/api';
+import type { Id } from '@/../convex/_generated/dataModel';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useAuth } from '@/hooks/useAuth';
+import { toast } from 'sonner';
+import {
+  Plus,
+  MoreVertical,
+  Edit,
+  Trash2,
+  Eye,
+  BookOpen,
+  Grid3x3,
+  List,
+  FileDown,
+  GraduationCap,
+  Award,
+  Lightbulb,
+  Baby,
+} from 'lucide-react';
+import { AddSubjectDialog } from '@/components/subjects/add-subject-dialog';
+import { EditSubjectDialog } from '@/components/subjects/edit-subject-dialog';
+import { ViewSubjectDialog } from '@/components/subjects/view-subject-dialog';
+import { DeleteSubjectDialog } from '@/components/subjects/delete-subject-dialog';
+import { BulkAddSubjectsDialog } from '@/components/subjects/bulk-add-subjects-dialog';
+import { DataTable, createSortableHeader, createSelectColumn } from '@/components/ui/data-table';
+import type { ColumnDef } from '@tanstack/react-table';
+import { exportToCSV, exportToPDF } from '../../../lib/exports';
+
+interface Subject {
+  _id: Id<'subjects'>;
+  schoolId: string;
+  subjectCode: string;
+  subjectName: string;
+  description?: string;
+  category: 'core' | 'elective' | 'extracurricular';
+  department: 'creche' | 'kindergarten' | 'primary' | 'junior_high';
+  status: 'active' | 'inactive';
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+}
+
+export default function SubjectsPage(): JSX.Element {
+  const { user } = useAuth();
+  const [showAddDialog, setShowAddDialog] = useState<boolean>(false);
+  const [showBulkAddDialog, setShowBulkAddDialog] = useState<boolean>(false);
+  const [selectedSubject, setSelectedSubject] = useState<Subject | null>(null);
+  const [showEditDialog, setShowEditDialog] = useState<boolean>(false);
+  const [showViewDialog, setShowViewDialog] = useState<boolean>(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
+  const [statusFilter, setStatusFilter] = useState<string>('all');
+  const [departmentFilter, setDepartmentFilter] = useState<string>('all');
+  const [categoryFilter, setCategoryFilter] = useState<string>('all');
+  const [viewMode, setViewMode] = useState<'card' | 'table'>('table');
+
+  // Fetch school data
+  const schoolAdmin = useQuery(
+    api.schoolAdmins.getByEmail,
+    user?.email ? { email: user.email } : 'skip'
+  );
+
+  const school = useQuery(
+    api.schools.getBySchoolId,
+    schoolAdmin?.schoolId ? { schoolId: schoolAdmin.schoolId } : 'skip'
+  );
+
+  // Fetch subjects data
+  const subjects = useQuery(
+    api.subjects.getSubjectsBySchool,
+    schoolAdmin?.schoolId ? { schoolId: schoolAdmin.schoolId } : 'skip'
+  );
+
+  const subjectStats = useQuery(
+    api.subjects.getSubjectStats,
+    schoolAdmin?.schoolId ? { schoolId: schoolAdmin.schoolId } : 'skip'
+  );
+
+  const updateSubjectStatus = useMutation(api.subjects.updateSubjectStatus);
+
+  // Show loading only while data is being fetched
+  if (!user) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <p className="text-muted-foreground">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // If user exists but no schoolAdmin found, show error
+  if (schoolAdmin === null) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <p className="text-muted-foreground">No school admin profile found</p>
+        </div>
+      </div>
+    );
+  }
+
+  // If schoolAdmin exists but no school found, show error
+  if (schoolAdmin && school !== undefined && !school) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <p className="text-muted-foreground">School not found</p>
+        </div>
+      </div>
+    );
+  }
+
+  // If still loading schoolAdmin or school, show loading
+  if (!schoolAdmin || !school) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <div className="text-center">
+          <p className="text-muted-foreground">Loading...</p>
+        </div>
+      </div>
+    );
+  }
+
+  // Filter subjects based on status, department, and category
+  const filteredSubjects = subjects?.filter(
+    (subject: Subject) => {
+      const statusMatch = statusFilter === 'all' || subject.status === statusFilter;
+      const departmentMatch = departmentFilter === 'all' || subject.department === departmentFilter;
+      const categoryMatch = categoryFilter === 'all' || subject.category === categoryFilter;
+      return statusMatch && departmentMatch && categoryMatch;
+    }
+  ) || [];
+
+  const getDepartmentBadge = (department: string): JSX.Element => {
+    switch (department) {
+      case 'creche':
+        return <Badge className="bg-orange-500">Creche</Badge>;
+      case 'kindergarten':
+        return <Badge className="bg-pink-500">Kindergarten</Badge>;
+      case 'primary':
+        return <Badge className="bg-blue-500">Primary</Badge>;
+      case 'junior_high':
+        return <Badge className="bg-purple-500">Junior High</Badge>;
+      default:
+        return <Badge>{department}</Badge>;
+    }
+  };
+
+  const getCategoryBadge = (category: string): JSX.Element => {
+    switch (category) {
+      case 'core':
+        return <Badge className="bg-green-600">Core</Badge>;
+      case 'elective':
+        return <Badge className="bg-blue-600">Elective</Badge>;
+      case 'extracurricular':
+        return <Badge className="bg-purple-600">Extracurricular</Badge>;
+      default:
+        return <Badge>{category}</Badge>;
+    }
+  };
+
+  const getStatusBadge = (status: string): JSX.Element => {
+    switch (status) {
+      case 'active':
+        return <Badge className="bg-green-500">Active</Badge>;
+      case 'inactive':
+        return <Badge className="bg-gray-500">Inactive</Badge>;
+      default:
+        return <Badge>{status}</Badge>;
+    }
+  };
+
+  const handleStatusChange = async (subjectId: Id<'subjects'>, newStatus: 'active' | 'inactive'): Promise<void> => {
+    try {
+      await updateSubjectStatus({
+        subjectId,
+        status: newStatus,
+        updatedBy: schoolAdmin._id,
+      });
+      toast.success(`Subject status updated to ${newStatus}`);
+    } catch (error) {
+      toast.error('Failed to update subject status');
+      console.error(error);
+    }
+  };
+
+  // Export handlers
+  const handleExportSingle = (subject: Subject, format: 'csv' | 'pdf'): void => {
+    const exportData = [{
+      subjectCode: subject.subjectCode,
+      subjectName: subject.subjectName,
+      category: subject.category,
+      department: subject.department,
+      description: subject.description || 'N/A',
+      status: subject.status,
+    }];
+
+    if (format === 'csv') {
+      exportToCSV(exportData, `subject_${subject.subjectCode}`);
+      toast.success('Subject exported as CSV');
+    } else {
+      exportToPDF(exportData, `subject_${subject.subjectCode}`, `Subject: ${subject.subjectName}`);
+      toast.success('Subject exported as PDF');
+    }
+  };
+
+  const handleExportBulk = (subjectsToExport: Subject[], format: 'csv' | 'pdf'): void => {
+    const exportData = subjectsToExport.map(subject => ({
+      subjectCode: subject.subjectCode,
+      subjectName: subject.subjectName,
+      category: subject.category,
+      department: subject.department,
+      description: subject.description || 'N/A',
+      status: subject.status,
+    }));
+
+    if (format === 'csv') {
+      exportToCSV(exportData, 'subjects');
+      toast.success(`${subjectsToExport.length} subjects exported as CSV`);
+    } else {
+      exportToPDF(exportData, 'subjects', 'Subjects Report');
+      toast.success(`${subjectsToExport.length} subjects exported as PDF`);
+    }
+  };
+
+  // Define columns for DataTable
+  const columns: ColumnDef<Subject>[] = [
+    createSelectColumn<Subject>(),
+    {
+      accessorKey: 'subjectCode',
+      header: createSortableHeader('Subject Code'),
+      cell: ({ row }) => (
+        <span className="font-medium">{row.getValue('subjectCode')}</span>
+      ),
+    },
+    {
+      accessorKey: 'subjectName',
+      header: createSortableHeader('Subject Name'),
+      cell: ({ row }) => (
+        <span className="font-semibold">{row.getValue('subjectName')}</span>
+      ),
+    },
+    {
+      accessorKey: 'category',
+      header: 'Category',
+      cell: ({ row }) => getCategoryBadge(row.getValue('category')),
+    },
+    {
+      accessorKey: 'department',
+      header: 'Department',
+      cell: ({ row }) => getDepartmentBadge(row.getValue('department')),
+    },
+    {
+      accessorKey: 'status',
+      header: createSortableHeader('Status'),
+      cell: ({ row }) => getStatusBadge(row.getValue('status')),
+    },
+    {
+      id: 'actions',
+      header: 'Actions',
+      cell: ({ row }) => {
+        const subject = row.original;
+        return (
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setSelectedSubject(subject);
+                setShowViewDialog(true);
+              }}
+            >
+              <Eye className="h-4 w-4" />
+            </Button>
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="sm">
+                  <MoreVertical className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuLabel>Actions</DropdownMenuLabel>
+                <DropdownMenuItem
+                  onClick={() => {
+                    setSelectedSubject(subject);
+                    setShowEditDialog(true);
+                  }}
+                >
+                  <Edit className="mr-2 h-4 w-4" />
+                  Edit
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>Export</DropdownMenuLabel>
+                <DropdownMenuItem onClick={() => handleExportSingle(subject, 'csv')}>
+                  <FileDown className="mr-2 h-4 w-4" />
+                  Export as CSV
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleExportSingle(subject, 'pdf')}>
+                  <FileDown className="mr-2 h-4 w-4" />
+                  Export as PDF
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel>Change Status</DropdownMenuLabel>
+                <DropdownMenuItem
+                  onClick={() => handleStatusChange(subject._id, 'active')}
+                  disabled={subject.status === 'active'}
+                >
+                  Set Active
+                </DropdownMenuItem>
+                <DropdownMenuItem
+                  onClick={() => handleStatusChange(subject._id, 'inactive')}
+                  disabled={subject.status === 'inactive'}
+                >
+                  Set Inactive
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  onClick={() => {
+                    setSelectedSubject(subject);
+                    setShowDeleteDialog(true);
+                  }}
+                  className="text-red-600"
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        );
+      },
+    },
+  ];
+
+  return (
+    <div className="container mx-auto py-6 space-y-6">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold">Subjects Management</h1>
+          <p className="text-muted-foreground">
+            Manage your school&apos;s subjects and curriculum
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Button variant="outline" onClick={() => setShowBulkAddDialog(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Bulk Add
+          </Button>
+          <Button onClick={() => setShowAddDialog(true)}>
+            <Plus className="mr-2 h-4 w-4" />
+            Add Subject
+          </Button>
+        </div>
+      </div>
+
+      {/* Statistics Cards */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card className="transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Total Subjects</CardTitle>
+            <BookOpen className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{subjectStats?.total || 0}</div>
+          </CardContent>
+        </Card>
+
+        <Card className="transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Active Subjects</CardTitle>
+            <Award className="h-4 w-4 text-green-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{subjectStats?.active || 0}</div>
+          </CardContent>
+        </Card>
+
+        <Card className="transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Core Subjects</CardTitle>
+            <GraduationCap className="h-4 w-4 text-green-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{subjectStats?.core || 0}</div>
+          </CardContent>
+        </Card>
+
+        <Card className="transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Electives</CardTitle>
+            <Lightbulb className="h-4 w-4 text-blue-600" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{subjectStats?.elective || 0}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Department Stats */}
+      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <Card className="transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Creche</CardTitle>
+            <Baby className="h-4 w-4 text-orange-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{subjectStats?.creche || 0}</div>
+          </CardContent>
+        </Card>
+
+        <Card className="transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Kindergarten</CardTitle>
+            <Baby className="h-4 w-4 text-pink-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{subjectStats?.kindergarten || 0}</div>
+          </CardContent>
+        </Card>
+
+        <Card className="transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Primary</CardTitle>
+            <BookOpen className="h-4 w-4 text-blue-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{subjectStats?.primary || 0}</div>
+          </CardContent>
+        </Card>
+
+        <Card className="transition-all duration-200 hover:shadow-lg hover:scale-105 cursor-pointer">
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Junior High</CardTitle>
+            <GraduationCap className="h-4 w-4 text-purple-500" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{subjectStats?.juniorHigh || 0}</div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Subjects Table/Card View */}
+      <Card>
+        <CardHeader>
+          <div className="flex flex-col gap-4">
+            <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+              <div>
+                <CardTitle>All Subjects</CardTitle>
+                <CardDescription>
+                  View and manage all subjects
+                </CardDescription>
+              </div>
+              <div className="flex gap-2">
+                <Button
+                  variant={viewMode === 'table' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setViewMode('table')}
+                >
+                  <List className="h-4 w-4 mr-2" />
+                  Table
+                </Button>
+                <Button
+                  variant={viewMode === 'card' ? 'default' : 'outline'}
+                  size="sm"
+                  onClick={() => setViewMode('card')}
+                >
+                  <Grid3x3 className="h-4 w-4 mr-2" />
+                  Card
+                </Button>
+              </div>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {!subjects || subjects.length === 0 ? (
+            <div className="text-center py-12">
+              <BookOpen className="mx-auto h-12 w-12 text-muted-foreground" />
+              <h3 className="mt-4 text-lg font-semibold">No subjects found</h3>
+              <p className="text-muted-foreground">
+                Get started by adding your first subject
+              </p>
+              <Button onClick={() => setShowAddDialog(true)} className="mt-4">
+                <Plus className="mr-2 h-4 w-4" />
+                Add Subject
+              </Button>
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {/* Filters Row */}
+              <div className="flex flex-wrap gap-2">
+                <div className="flex-1 min-w-[160px]">
+                  <Select value={statusFilter} onValueChange={setStatusFilter}>
+                    <SelectTrigger className="h-9">
+                      <SelectValue placeholder="Filter by Status" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Statuses</SelectItem>
+                      <SelectItem value="active">Active</SelectItem>
+                      <SelectItem value="inactive">Inactive</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                
+                <div className="flex-1 min-w-[160px]">
+                  <Select value={categoryFilter} onValueChange={setCategoryFilter}>
+                    <SelectTrigger className="h-9">
+                      <SelectValue placeholder="Filter by Category" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Categories</SelectItem>
+                      <SelectItem value="core">Core</SelectItem>
+                      <SelectItem value="elective">Elective</SelectItem>
+                      <SelectItem value="extracurricular">Extracurricular</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                
+                <div className="flex-1 min-w-[160px]">
+                  <Select value={departmentFilter} onValueChange={setDepartmentFilter}>
+                    <SelectTrigger className="h-9">
+                      <SelectValue placeholder="Filter by Department" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Departments</SelectItem>
+                      <SelectItem value="creche">Creche</SelectItem>
+                      <SelectItem value="kindergarten">Kindergarten</SelectItem>
+                      <SelectItem value="primary">Primary</SelectItem>
+                      <SelectItem value="junior_high">Junior High</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              {viewMode === 'table' ? (
+                <DataTable
+                  columns={columns}
+                  data={filteredSubjects}
+                  searchKey="subjectName"
+                  searchPlaceholder="Search by subject name..."
+                  exportFormats={['csv', 'pdf']}
+                  onExport={(rows, format) => handleExportBulk(rows, format as "csv" | "pdf")}
+                />
+              ) : (
+                <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+                  {filteredSubjects.map((subject) => (
+                    <Card key={subject._id} className="transition-all duration-200 hover:shadow-lg cursor-pointer">
+                      <CardHeader>
+                        <div className="flex items-start justify-between">
+                          <div className="space-y-1">
+                            <CardTitle className="text-lg">{subject.subjectName}</CardTitle>
+                            <p className="text-sm text-muted-foreground">{subject.subjectCode}</p>
+                          </div>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button variant="ghost" size="sm">
+                                <MoreVertical className="h-4 w-4" />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent align="end">
+                              <DropdownMenuItem onClick={() => { setSelectedSubject(subject); setShowViewDialog(true); }}>
+                                <Eye className="mr-2 h-4 w-4" />
+                                View
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => { setSelectedSubject(subject); setShowEditDialog(true); }}>
+                                <Edit className="mr-2 h-4 w-4" />
+                                Edit
+                              </DropdownMenuItem>
+                              <DropdownMenuItem onClick={() => { setSelectedSubject(subject); setShowDeleteDialog(true); }} className="text-red-600">
+                                <Trash2 className="mr-2 h-4 w-4" />
+                                Delete
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
+                        </div>
+                      </CardHeader>
+                      <CardContent className="space-y-3">
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm text-muted-foreground">Category:</span>
+                          {getCategoryBadge(subject.category)}
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm text-muted-foreground">Department:</span>
+                          {getDepartmentBadge(subject.department)}
+                        </div>
+                        <div className="flex items-center justify-between">
+                          <span className="text-sm text-muted-foreground">Status:</span>
+                          {getStatusBadge(subject.status)}
+                        </div>
+                        {subject.description && (
+                          <div className="pt-2">
+                            <p className="text-sm text-muted-foreground line-clamp-2">{subject.description}</p>
+                          </div>
+                        )}
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              )}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Dialogs */}
+      <AddSubjectDialog
+        open={showAddDialog}
+        onOpenChange={setShowAddDialog}
+        schoolId={schoolAdmin.schoolId}
+        createdBy={schoolAdmin._id}
+      />
+
+      <BulkAddSubjectsDialog
+        open={showBulkAddDialog}
+        onOpenChange={setShowBulkAddDialog}
+        schoolId={schoolAdmin.schoolId}
+        createdBy={schoolAdmin._id}
+      />
+
+      {selectedSubject && (
+        <>
+          <EditSubjectDialog
+            open={showEditDialog}
+            onOpenChange={setShowEditDialog}
+            subjectData={selectedSubject}
+            updatedBy={schoolAdmin._id}
+          />
+
+          <ViewSubjectDialog
+            open={showViewDialog}
+            onOpenChange={setShowViewDialog}
+            subjectData={selectedSubject}
+          />
+
+          <DeleteSubjectDialog
+            open={showDeleteDialog}
+            onOpenChange={setShowDeleteDialog}
+            subjectData={selectedSubject}
+            deletedBy={schoolAdmin._id}
+            onDeleted={() => setSelectedSubject(null)}
+          />
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/school-admin/app-sidebar.tsx
+++ b/src/components/school-admin/app-sidebar.tsx
@@ -62,6 +62,11 @@ const menuItems = [
     icon: BookOpen,
     url: '/school-admin/classes',
   },
+    {
+    title: 'Subjects',
+    icon: GraduationCap,
+    url: '/school-admin/subjects',
+  },
   {
     title: 'Subscription',
     icon: CreditCard,

--- a/src/components/subjects/bulk-add-subjects-dialog.tsx
+++ b/src/components/subjects/bulk-add-subjects-dialog.tsx
@@ -1,0 +1,251 @@
+'use client';
+
+import { JSX, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/../convex/_generated/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Card, CardContent } from '@/components/ui/card';
+import { toast } from 'sonner';
+import { Plus, Trash2 } from 'lucide-react';
+
+interface SubjectInput {
+  id: string;
+  subjectName: string;
+  description: string;
+  category: 'core' | 'elective' | 'extracurricular';
+  department: 'creche' | 'kindergarten' | 'primary' | 'junior_high';
+}
+
+interface BulkAddSubjectsDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  schoolId: string;
+  createdBy: string;
+}
+
+export function BulkAddSubjectsDialog({
+  open,
+  onOpenChange,
+  schoolId,
+  createdBy,
+}: BulkAddSubjectsDialogProps): JSX.Element {
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [subjects, setSubjects] = useState<SubjectInput[]>([
+    { id: '1', subjectName: '', description: '', category: 'core', department: 'primary' },
+  ]);
+
+  const addBulkSubjects = useMutation(api.subjects.addBulkSubjects);
+
+  const addSubjectRow = (): void => {
+    setSubjects((prev) => [
+      ...prev,
+      { 
+        id: Date.now().toString(), 
+        subjectName: '', 
+        description: '', 
+        category: 'core', 
+        department: 'primary' 
+      },
+    ]);
+  };
+
+  const removeSubjectRow = (id: string): void => {
+    if (subjects.length > 1) {
+      setSubjects((prev) => prev.filter((s) => s.id !== id));
+    }
+  };
+
+  const updateSubject = (id: string, field: string, value: string): void => {
+    setSubjects((prev) =>
+      prev.map((s) =>
+        s.id === id ? { ...s, [field]: value } : s
+      )
+    );
+  };
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      // Validation
+      const validSubjects = subjects.filter((s) => s.subjectName.trim() !== '');
+      
+      if (validSubjects.length === 0) {
+        toast.error('Please add at least one subject with a name');
+        setIsSubmitting(false);
+        return;
+      }
+
+      const results = await addBulkSubjects({
+        schoolId,
+        subjects: validSubjects.map((s) => ({
+          subjectName: s.subjectName,
+          description: s.description || undefined,
+          category: s.category,
+          department: s.department,
+        })),
+        createdBy,
+      });
+
+      const successCount = results.filter((r) => r.success).length;
+      const failureCount = results.length - successCount;
+
+      if (successCount > 0) {
+        toast.success(`${successCount} subject${successCount > 1 ? 's' : ''} added successfully`);
+      }
+      if (failureCount > 0) {
+        toast.error(`${failureCount} subject${failureCount > 1 ? 's' : ''} failed to add`);
+      }
+      
+      // Reset form
+      setSubjects([{ id: '1', subjectName: '', description: '', category: 'core', department: 'primary' }]);
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to add subjects');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogHeader>
+          <DialogTitle>Bulk Add Subjects</DialogTitle>
+          <DialogDescription>
+            Add multiple subjects at once. Fill in the details for each subject.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-3 max-h-[60vh] overflow-y-auto pr-2">
+            {subjects.map((subject, index) => (
+              <Card key={subject.id}>
+                <CardContent className="pt-6">
+                  <div className="space-y-4">
+                    <div className="flex items-center justify-between">
+                      <h4 className="text-sm font-semibold">Subject #{index + 1}</h4>
+                      {subjects.length > 1 && (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => removeSubjectRow(subject.id)}
+                        >
+                          <Trash2 className="h-4 w-4 text-red-500" />
+                        </Button>
+                      )}
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label>Subject Name *</Label>
+                      <Input
+                        placeholder="e.g., Mathematics, English"
+                        value={subject.subjectName}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                          updateSubject(subject.id, 'subjectName', e.target.value)
+                        }
+                      />
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label>Description (Optional)</Label>
+                      <Textarea
+                        placeholder="Brief description..."
+                        value={subject.description}
+                        onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                          updateSubject(subject.id, 'description', e.target.value)
+                        }
+                        rows={2}
+                      />
+                    </div>
+
+                    <div className="grid grid-cols-2 gap-4">
+                      <div className="space-y-2">
+                        <Label>Category *</Label>
+                        <Select
+                          value={subject.category}
+                          onValueChange={(value: string) => updateSubject(subject.id, 'category', value)}
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="core">Core</SelectItem>
+                            <SelectItem value="elective">Elective</SelectItem>
+                            <SelectItem value="extracurricular">Extracurricular</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+
+                      <div className="space-y-2">
+                        <Label>Department *</Label>
+                        <Select
+                          value={subject.department}
+                          onValueChange={(value: string) => updateSubject(subject.id, 'department', value)}
+                        >
+                          <SelectTrigger>
+                            <SelectValue />
+                          </SelectTrigger>
+                          <SelectContent>
+                            <SelectItem value="creche">Creche</SelectItem>
+                            <SelectItem value="kindergarten">Kindergarten</SelectItem>
+                            <SelectItem value="primary">Primary</SelectItem>
+                            <SelectItem value="junior_high">Junior High</SelectItem>
+                          </SelectContent>
+                        </Select>
+                      </div>
+                    </div>
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={addSubjectRow}
+            className="w-full"
+          >
+            <Plus className="mr-2 h-4 w-4" />
+            Add Another Subject
+          </Button>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Adding Subjects...' : `Add ${subjects.length} Subject${subjects.length > 1 ? 's' : ''}`}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/subjects/delete-subject-dialog.tsx
+++ b/src/components/subjects/delete-subject-dialog.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { JSX, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/../convex/_generated/api';
+import type { Id } from '@/../convex/_generated/dataModel';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+
+interface Subject {
+  _id: Id<'subjects'>;
+  schoolId: string;
+  subjectCode: string;
+  subjectName: string;
+  description?: string;
+  category: 'core' | 'elective' | 'extracurricular';
+  department: 'creche' | 'kindergarten' | 'primary' | 'junior_high';
+  status: 'active' | 'inactive';
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+}
+
+interface DeleteSubjectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  subjectData: Subject;
+  deletedBy: string;
+  onDeleted: () => void;
+}
+
+export function DeleteSubjectDialog({
+  open,
+  onOpenChange,
+  subjectData,
+  deletedBy,
+  onDeleted,
+}: DeleteSubjectDialogProps): JSX.Element {
+  const [isDeleting, setIsDeleting] = useState<boolean>(false);
+  const deleteSubject = useMutation(api.subjects.deleteSubject);
+
+  const handleDelete = async (): Promise<void> => {
+    setIsDeleting(true);
+    try {
+      await deleteSubject({
+        subjectId: subjectData._id,
+        deletedBy,
+      });
+      toast.success('Subject deleted successfully');
+      onDeleted();
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to delete subject');
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Subject</AlertDialogTitle>
+          <AlertDialogDescription>
+            <span className="block">
+              Are you sure you want to delete <strong>{subjectData.subjectName}</strong> ({subjectData.subjectCode})?
+            </span>
+            <span className="block mt-2">This action cannot be undone.</span>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isDeleting}
+          >
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={isDeleting}
+          >
+            {isDeleting ? 'Deleting...' : 'Delete Subject'}
+          </Button>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/subjects/edit-subject-dialog.tsx
+++ b/src/components/subjects/edit-subject-dialog.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useState, useEffect, JSX } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '@/../convex/_generated/api';
+import type { Id } from '@/../convex/_generated/dataModel';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
+
+interface Subject {
+  _id: Id<'subjects'>;
+  schoolId: string;
+  subjectCode: string;
+  subjectName: string;
+  description?: string;
+  category: 'core' | 'elective' | 'extracurricular';
+  department: 'creche' | 'kindergarten' | 'primary' | 'junior_high';
+  status: 'active' | 'inactive';
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+}
+
+interface EditSubjectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  subjectData: Subject;
+  updatedBy: string;
+}
+
+export function EditSubjectDialog({
+  open,
+  onOpenChange,
+  subjectData,
+  updatedBy,
+}: EditSubjectDialogProps): JSX.Element {
+  const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
+  const [formData, setFormData] = useState({
+    subjectName: '',
+    description: '',
+    category: 'core' as 'core' | 'elective' | 'extracurricular',
+    department: 'primary' as 'creche' | 'kindergarten' | 'primary' | 'junior_high',
+  });
+
+  const updateSubject = useMutation(api.subjects.updateSubject);
+
+  useEffect(() => {
+    if (subjectData) {
+      setFormData({
+        subjectName: subjectData.subjectName,
+        description: subjectData.description || '',
+        category: subjectData.category,
+        department: subjectData.department,
+      });
+    }
+  }, [subjectData]);
+
+  const handleInputChange = (field: string, value: string): void => {
+    setFormData((prev) => ({ ...prev, [field]: value }));
+  };
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    setIsSubmitting(true);
+
+    try {
+      // Validation
+      if (!formData.subjectName || !formData.category || !formData.department) {
+        toast.error('Please fill in all required fields');
+        setIsSubmitting(false);
+        return;
+      }
+
+      await updateSubject({
+        subjectId: subjectData._id,
+        subjectName: formData.subjectName,
+        description: formData.description || undefined,
+        category: formData.category,
+        department: formData.department,
+        updatedBy,
+      });
+
+      toast.success('Subject updated successfully');
+      onOpenChange(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to update subject');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Subject</DialogTitle>
+          <DialogDescription>
+            Update the subject details. Required fields are marked with an asterisk (*).
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          {/* Subject Code (Read-only) */}
+          <div className="space-y-2">
+            <Label htmlFor="subjectCode">Subject Code</Label>
+            <Input
+              id="subjectCode"
+              value={subjectData.subjectCode}
+              disabled
+              className="bg-muted"
+            />
+          </div>
+
+          {/* Subject Name */}
+          <div className="space-y-2">
+            <Label htmlFor="subjectName">Subject Name *</Label>
+            <Input
+              id="subjectName"
+              placeholder="e.g., Mathematics, English"
+              value={formData.subjectName}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => handleInputChange('subjectName', e.target.value)}
+              required
+            />
+          </div>
+
+          {/* Description */}
+          <div className="space-y-2">
+            <Label htmlFor="description">Description (Optional)</Label>
+            <Textarea
+              id="description"
+              placeholder="Brief description of the subject..."
+              value={formData.description}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) => handleInputChange('description', e.target.value)}
+              rows={3}
+            />
+          </div>
+
+          {/* Category and Department */}
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-2">
+              <Label htmlFor="category">Category *</Label>
+              <Select value={formData.category} onValueChange={(value: string) => handleInputChange('category', value)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="core">Core</SelectItem>
+                  <SelectItem value="elective">Elective</SelectItem>
+                  <SelectItem value="extracurricular">Extracurricular</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="department">Department *</Label>
+              <Select value={formData.department} onValueChange={(value: string) => handleInputChange('department', value)}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="creche">Creche</SelectItem>
+                  <SelectItem value="kindergarten">Kindergarten</SelectItem>
+                  <SelectItem value="primary">Primary</SelectItem>
+                  <SelectItem value="junior_high">Junior High</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isSubmitting}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Updating Subject...' : 'Update Subject'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/subjects/view-subject-dialog.tsx
+++ b/src/components/subjects/view-subject-dialog.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import type { Id } from '@/../convex/_generated/dataModel';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Badge } from '@/components/ui/badge';
+import { Separator } from '@/components/ui/separator';
+import { JSX } from 'react';
+
+interface Subject {
+  _id: Id<'subjects'>;
+  schoolId: string;
+  subjectCode: string;
+  subjectName: string;
+  description?: string;
+  category: 'core' | 'elective' | 'extracurricular';
+  department: 'creche' | 'kindergarten' | 'primary' | 'junior_high';
+  status: 'active' | 'inactive';
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+}
+
+interface ViewSubjectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  subjectData: Subject;
+}
+
+export function ViewSubjectDialog({
+  open,
+  onOpenChange,
+  subjectData,
+}: ViewSubjectDialogProps): JSX.Element {
+  const getDepartmentBadge = (department: string): JSX.Element => {
+    switch (department) {
+      case 'creche':
+        return <Badge className="bg-orange-500">Creche</Badge>;
+      case 'kindergarten':
+        return <Badge className="bg-pink-500">Kindergarten</Badge>;
+      case 'primary':
+        return <Badge className="bg-blue-500">Primary</Badge>;
+      case 'junior_high':
+        return <Badge className="bg-purple-500">Junior High</Badge>;
+      default:
+        return <Badge>{department}</Badge>;
+    }
+  };
+
+  const getCategoryBadge = (category: string): JSX.Element => {
+    switch (category) {
+      case 'core':
+        return <Badge className="bg-green-600">Core</Badge>;
+      case 'elective':
+        return <Badge className="bg-blue-600">Elective</Badge>;
+      case 'extracurricular':
+        return <Badge className="bg-purple-600">Extracurricular</Badge>;
+      default:
+        return <Badge>{category}</Badge>;
+    }
+  };
+
+  const getStatusBadge = (status: string): JSX.Element => {
+    switch (status) {
+      case 'active':
+        return <Badge className="bg-green-500">Active</Badge>;
+      case 'inactive':
+        return <Badge className="bg-gray-500">Inactive</Badge>;
+      default:
+        return <Badge>{status}</Badge>;
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="text-2xl">Subject Details</DialogTitle>
+          <DialogDescription>
+            Comprehensive information about this subject
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {/* Header Section */}
+          <div className="space-y-3">
+            <div className="flex items-start justify-between">
+              <div>
+                <h3 className="text-xl font-semibold">{subjectData.subjectName}</h3>
+                <p className="text-sm text-muted-foreground">{subjectData.subjectCode}</p>
+              </div>
+              {getStatusBadge(subjectData.status)}
+            </div>
+          </div>
+
+          <Separator />
+
+          {/* Subject Information */}
+          <div className="space-y-4">
+            <h4 className="font-semibold text-sm uppercase text-muted-foreground">Subject Information</h4>
+            
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm text-muted-foreground">Category</p>
+                <div className="mt-1">{getCategoryBadge(subjectData.category)}</div>
+              </div>
+              
+              <div>
+                <p className="text-sm text-muted-foreground">Department</p>
+                <div className="mt-1">{getDepartmentBadge(subjectData.department)}</div>
+              </div>
+            </div>
+
+            {subjectData.description && (
+              <div>
+                <p className="text-sm text-muted-foreground">Description</p>
+                <p className="mt-1 text-sm">{subjectData.description}</p>
+              </div>
+            )}
+          </div>
+
+          <Separator />
+
+          {/* Metadata */}
+          <div className="space-y-4">
+            <h4 className="font-semibold text-sm uppercase text-muted-foreground">Metadata</h4>
+            
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <p className="text-sm text-muted-foreground">Created At</p>
+                <p className="text-sm font-medium">{new Date(subjectData.createdAt).toLocaleDateString()}</p>
+              </div>
+              
+              <div>
+                <p className="text-sm text-muted-foreground">Last Updated</p>
+                <p className="text-sm font-medium">{new Date(subjectData.updatedAt).toLocaleDateString()}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
- Introduced a new subjects table in the schema, including fields for subject details such as schoolId, subjectCode, subjectName, description, category, department, status, createdAt, updatedAt, and createdBy.
- Updated API definitions to include the new subjects module, enhancing access to subject-related functionalities.
- Modified the AppSidebar to include a navigation item for Subjects, improving admin access to subject management features.