### PR TITLE
feat: expand schema with timetables and periods

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -34,6 +34,8 @@ import type * as support from "../support.js";
 import type * as supportTickets from "../supportTickets.js";
 import type * as teachers from "../teachers.js";
 import type * as terms from "../terms.js";
+import type * as timetableAssignments from "../timetableAssignments.js";
+import type * as timetables from "../timetables.js";
 import type * as trialManagement from "../trialManagement.js";
 import type * as userSettings from "../userSettings.js";
 
@@ -70,6 +72,8 @@ declare const fullApi: ApiFromModules<{
   supportTickets: typeof supportTickets;
   teachers: typeof teachers;
   terms: typeof terms;
+  timetableAssignments: typeof timetableAssignments;
+  timetables: typeof timetables;
   trialManagement: typeof trialManagement;
   userSettings: typeof userSettings;
 }>;

--- a/convex/timetableAssignments.ts
+++ b/convex/timetableAssignments.ts
@@ -1,0 +1,51 @@
+import { v } from 'convex/values';
+import { query } from './_generated/server';
+
+// Get all assignments for a specific teacher
+export const getAssignmentsByTeacher = query({
+  args: { 
+    schoolId: v.string(), 
+    teacherId: v.string() 
+  },
+  handler: async (ctx, args) => {
+    const assignments = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_teacher', (q) => 
+        q.eq('schoolId', args.schoolId).eq('teacherId', args.teacherId)
+      )
+      .collect();
+    
+    return assignments;
+  },
+});
+
+// Get all assignments for a specific class
+export const getAssignmentsByClass = query({
+  args: { 
+    schoolId: v.string(), 
+    classId: v.string() 
+  },
+  handler: async (ctx, args) => {
+    const assignments = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_class', (q) => 
+        q.eq('schoolId', args.schoolId).eq('classId', args.classId)
+      )
+      .collect();
+    
+    return assignments;
+  },
+});
+
+// Get all assignments for a school
+export const getAllAssignments = query({
+  args: { schoolId: v.string() },
+  handler: async (ctx, args) => {
+    const assignments = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_school', (q) => q.eq('schoolId', args.schoolId))
+      .collect();
+    
+    return assignments;
+  },
+});

--- a/convex/timetables.ts
+++ b/convex/timetables.ts
@@ -1,0 +1,401 @@
+import { v } from 'convex/values';
+import { mutation, query } from './_generated/server';
+import type { Id } from './_generated/dataModel';
+
+type Day = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday';
+
+// Get all timetables for a school
+export const getTimetables = query({
+  args: { schoolId: v.string() },
+  handler: async (ctx, args) => {
+    const timetables = await ctx.db
+      .query('timetables')
+      .withIndex('by_school', (q) => q.eq('schoolId', args.schoolId))
+      .collect();
+    return timetables;
+  },
+});
+
+// Get a single timetable with its periods grouped by day
+export const getTimetable = query({
+  args: { timetableId: v.id('timetables') },
+  handler: async (ctx, args) => {
+    const timetable = await ctx.db.get(args.timetableId);
+    if (!timetable) return null;
+
+    const periods = await ctx.db
+      .query('periods')
+      .withIndex('by_timetable', (q) => q.eq('timetableId', args.timetableId))
+      .collect();
+
+    // Group periods by day
+    const periodsByDay: Record<Day, typeof periods> = {
+      monday: [],
+      tuesday: [],
+      wednesday: [],
+      thursday: [],
+      friday: [],
+    };
+
+    periods.forEach((period) => {
+      periodsByDay[period.day].push(period);
+    });
+
+    return { timetable, periodsByDay };
+  },
+});
+
+// Get timetable assignments for a specific timetable
+export const getAssignments = query({
+  args: { timetableId: v.id('timetables') },
+  handler: async (ctx, args) => {
+    const assignments = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_timetable', (q) => q.eq('timetableId', args.timetableId))
+      .collect();
+    return assignments;
+  },
+});
+
+// Get timetables by class
+export const getTimetablesByClass = query({
+  args: { schoolId: v.string(), classId: v.string() },
+  handler: async (ctx, args) => {
+    const timetables = await ctx.db
+      .query('timetables')
+      .withIndex('by_class', (q) => 
+        q.eq('schoolId', args.schoolId).eq('classId', args.classId)
+      )
+      .collect();
+    return timetables;
+  },
+});
+
+// Get timetables by teacher
+export const getTimetablesByTeacher = query({
+  args: { schoolId: v.string(), teacherId: v.string() },
+  handler: async (ctx, args) => {
+    // Get all assignments for this teacher
+    const assignments = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_teacher', (q) => 
+        q.eq('schoolId', args.schoolId).eq('teacherId', args.teacherId)
+      )
+      .collect();
+
+    // Get unique timetable IDs
+    const timetableIds = [...new Set(assignments.map(a => a.timetableId))];
+
+    // Get all timetables
+    const timetables = await Promise.all(
+      timetableIds.map(id => ctx.db.get(id))
+    );
+
+    return timetables.filter((t): t is NonNullable<typeof t> => t !== null);
+  },
+});
+
+// Create a new weekly timetable with default periods for all weekdays
+export const createTimetable = mutation({
+  args: {
+    schoolId: v.string(),
+    classId: v.string(),
+    className: v.string(),
+    academicYearId: v.optional(v.string()),
+    termId: v.optional(v.string()),
+    createdBy: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Check if timetable already exists for this class
+    const existing = await ctx.db
+      .query('timetables')
+      .withIndex('by_class', (q) => 
+        q.eq('schoolId', args.schoolId).eq('classId', args.classId)
+      )
+      .first();
+
+    if (existing) {
+      throw new Error(`Weekly timetable for ${args.className} already exists`);
+    }
+
+    // Create timetable
+    const timetableId = await ctx.db.insert('timetables', {
+      schoolId: args.schoolId,
+      classId: args.classId,
+      className: args.className,
+      academicYearId: args.academicYearId,
+      termId: args.termId,
+      status: 'active',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      createdBy: args.createdBy,
+    });
+
+    // Default periods structure
+    const defaultPeriods = [
+      { name: 'Assembly', startTime: '07:30', endTime: '08:00', type: 'break' as const },
+      { name: 'Period 1', startTime: '08:00', endTime: '09:10', type: 'class' as const },
+      { name: 'Period 2', startTime: '09:10', endTime: '10:20', type: 'class' as const },
+      { name: 'Break Time', startTime: '10:20', endTime: '10:40', type: 'break' as const },
+      { name: 'Period 3', startTime: '10:45', endTime: '11:55', type: 'class' as const },
+      { name: 'Period 4', startTime: '11:55', endTime: '13:05', type: 'class' as const },
+      { name: 'Lunch Time', startTime: '13:05', endTime: '13:35', type: 'break' as const },
+      { name: 'Period 5', startTime: '13:35', endTime: '14:45', type: 'class' as const },
+      { name: 'Period 6', startTime: '14:45', endTime: '15:55', type: 'class' as const },
+      { name: 'Closing', startTime: '15:55', endTime: '16:00', type: 'break' as const },
+    ];
+
+    // Create periods for all 5 weekdays
+    const weekdays: Day[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
+
+    for (const day of weekdays) {
+      for (const period of defaultPeriods) {
+        await ctx.db.insert('periods', {
+          timetableId,
+          day,
+          periodName: period.name,
+          startTime: period.startTime,
+          endTime: period.endTime,
+          periodType: period.type,
+          duration: calculateDuration(period.startTime, period.endTime),
+          createdAt: new Date().toISOString(),
+        });
+      }
+    }
+
+    return timetableId;
+  },
+});
+
+// Update a timetable
+export const updateTimetable = mutation({
+  args: {
+    timetableId: v.id('timetables'),
+    status: v.optional(v.union(v.literal('active'), v.literal('inactive'))),
+  },
+  handler: async (ctx, args) => {
+    const { timetableId, ...updates } = args;
+    
+    await ctx.db.patch(timetableId, {
+      ...updates,
+      updatedAt: new Date().toISOString(),
+    });
+
+    return timetableId;
+  },
+});
+
+// Delete a timetable and its periods/assignments
+export const deleteTimetable = mutation({
+  args: { timetableId: v.id('timetables') },
+  handler: async (ctx, args) => {
+    // Delete all periods
+    const periods = await ctx.db
+      .query('periods')
+      .withIndex('by_timetable', (q) => q.eq('timetableId', args.timetableId))
+      .collect();
+    
+    for (const period of periods) {
+      await ctx.db.delete(period._id);
+    }
+
+    // Delete all assignments
+    const assignments = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_timetable', (q) => q.eq('timetableId', args.timetableId))
+      .collect();
+    
+    for (const assignment of assignments) {
+      await ctx.db.delete(assignment._id);
+    }
+
+    // Delete timetable
+    await ctx.db.delete(args.timetableId);
+  },
+});
+
+// Bulk delete timetables
+export const bulkDeleteTimetables = mutation({
+  args: { timetableIds: v.array(v.id('timetables')) },
+  handler: async (ctx, args) => {
+    for (const timetableId of args.timetableIds) {
+      // Delete all periods
+      const periods = await ctx.db
+        .query('periods')
+        .withIndex('by_timetable', (q) => q.eq('timetableId', timetableId))
+        .collect();
+      
+      for (const period of periods) {
+        await ctx.db.delete(period._id);
+      }
+
+      // Delete all assignments
+      const assignments = await ctx.db
+        .query('timetableAssignments')
+        .withIndex('by_timetable', (q) => q.eq('timetableId', timetableId))
+        .collect();
+      
+      for (const assignment of assignments) {
+        await ctx.db.delete(assignment._id);
+      }
+
+      // Delete timetable
+      await ctx.db.delete(timetableId);
+    }
+  },
+});
+
+// Update period times (for inline editing)
+export const updatePeriod = mutation({
+  args: {
+    periodId: v.id('periods'),
+    startTime: v.string(),
+    endTime: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const duration = calculateDuration(args.startTime, args.endTime);
+    
+    await ctx.db.patch(args.periodId, {
+      startTime: args.startTime,
+      endTime: args.endTime,
+      duration,
+    });
+
+    return args.periodId;
+  },
+});
+
+// Assign teacher and subject to a period
+export const assignTeacherToSlot = mutation({
+  args: {
+    timetableId: v.id('timetables'),
+    periodId: v.id('periods'),
+    teacherId: v.string(),
+    teacherName: v.string(),
+    subjectId: v.string(),
+    subjectName: v.string(),
+    classId: v.string(),
+    className: v.string(),
+    schoolId: v.string(),
+    day: v.union(
+      v.literal('monday'),
+      v.literal('tuesday'),
+      v.literal('wednesday'),
+      v.literal('thursday'),
+      v.literal('friday')
+    ),
+    startTime: v.string(),
+    endTime: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Check for teacher conflicts (same teacher, same day, overlapping time)
+    const existingAssignments = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_teacher', (q) => 
+        q.eq('schoolId', args.schoolId).eq('teacherId', args.teacherId)
+      )
+      .filter((q) => q.eq(q.field('day'), args.day))
+      .collect();
+
+    // Check for time overlap
+    for (const assignment of existingAssignments) {
+      if (assignment.periodId !== args.periodId) {
+        const hasOverlap = checkTimeOverlap(
+          args.startTime,
+          args.endTime,
+          assignment.startTime,
+          assignment.endTime
+        );
+
+        if (hasOverlap) {
+          throw new Error(
+            `Teacher ${args.teacherName} is already assigned to ${assignment.className} during this time on ${args.day}`
+          );
+        }
+      }
+    }
+
+    // Check if assignment already exists for this period
+    const existing = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_period', (q) => q.eq('periodId', args.periodId))
+      .first();
+
+    if (existing) {
+      // Update existing assignment
+      await ctx.db.patch(existing._id, {
+        teacherId: args.teacherId,
+        teacherName: args.teacherName,
+        subjectId: args.subjectId,
+        subjectName: args.subjectName,
+        updatedAt: new Date().toISOString(),
+      });
+      return existing._id;
+    } else {
+      // Create new assignment
+      const assignmentId = await ctx.db.insert('timetableAssignments', {
+        timetableId: args.timetableId,
+        periodId: args.periodId,
+        teacherId: args.teacherId,
+        teacherName: args.teacherName,
+        subjectId: args.subjectId,
+        subjectName: args.subjectName,
+        classId: args.classId,
+        className: args.className,
+        schoolId: args.schoolId,
+        day: args.day,
+        startTime: args.startTime,
+        endTime: args.endTime,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      });
+      return assignmentId;
+    }
+  },
+});
+
+// Remove assignment from a period
+export const removeAssignment = mutation({
+  args: { periodId: v.id('periods') },
+  handler: async (ctx, args) => {
+    const assignment = await ctx.db
+      .query('timetableAssignments')
+      .withIndex('by_period', (q) => q.eq('periodId', args.periodId))
+      .first();
+
+    if (assignment) {
+      await ctx.db.delete(assignment._id);
+    }
+  },
+});
+
+// Helper function to calculate duration in minutes
+function calculateDuration(startTime: string, endTime: string): number {
+  const [startHour, startMin] = startTime.split(':').map(Number);
+  const [endHour, endMin] = endTime.split(':').map(Number);
+  
+  const startMinutes = startHour * 60 + startMin;
+  const endMinutes = endHour * 60 + endMin;
+  
+  return endMinutes - startMinutes;
+}
+
+// Helper function to check time overlap
+function checkTimeOverlap(
+  start1: string,
+  end1: string,
+  start2: string,
+  end2: string
+): boolean {
+  const s1 = timeToMinutes(start1);
+  const e1 = timeToMinutes(end1);
+  const s2 = timeToMinutes(start2);
+  const e2 = timeToMinutes(end2);
+
+  return s1 < e2 && s2 < e1;
+}
+
+function timeToMinutes(time: string): number {
+  const [hour, min] = time.split(':').map(Number);
+  return hour * 60 + min;
+}

--- a/src/app/school-admin/timetable/page.tsx
+++ b/src/app/school-admin/timetable/page.tsx
@@ -1,0 +1,613 @@
+'use client';
+
+import { useState, useMemo, useCallback, JSX } from 'react';
+import { useQuery, useConvex } from 'convex/react';
+import { api } from '../../../../convex/_generated/api';
+import { useAuth } from '@/hooks/useAuth';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Plus,
+  Search,
+  Download,
+  Trash2,
+  Clock,
+  Filter,
+  FileText,
+  Users,
+  GraduationCap,
+} from 'lucide-react';
+import { toast } from 'sonner';
+import type { Id } from '../../../../convex/_generated/dataModel';
+import { AddTimetableDialog } from '@/components/timetable/add-timetable-dialog';
+import { DeleteTimetableDialog } from '@/components/timetable/delete-timetable-dialog';
+import { BulkDeleteTimetablesDialog } from '@/components/timetable/bulk-delete-timetables-dialog';
+import { TimetableView } from '@/components/timetable/timetable-view';
+import { 
+  exportClassTimetablePDF, 
+  exportTeacherSchedulePDF, 
+  exportMasterTimetablePDF 
+} from '@/lib/timetable-export';
+
+interface Timetable {
+  _id: Id<'timetables'>;
+  _creationTime: number;
+  schoolId: string;
+  classId: string;
+  className: string;
+  academicYearId?: string;
+  termId?: string;
+  status: 'active' | 'inactive';
+  createdAt: string;
+  updatedAt: string;
+  createdBy: string;
+}
+
+interface Class {
+  _id: Id<'classes'>;
+  className: string;
+  status: 'active' | 'inactive';
+}
+
+interface Teacher {
+  _id: Id<'teachers'>;
+  teacherId: string;
+  firstName: string;
+  lastName: string;
+  status: 'active' | 'on_leave' | 'inactive';
+}
+
+interface Period {
+  _id: Id<'periods'>;
+  timetableId: Id<'timetables'>;
+  periodName: string;
+  startTime: string;
+  endTime: string;
+  periodType: 'class' | 'break';
+  day: 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday';
+}
+
+interface Assignment {
+  _id: Id<'timetableAssignments'>;
+  periodId: Id<'periods'>;
+  subjectName: string;
+  teacherName: string;
+  subjectColor?: string;
+  day: 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday';
+  className: string;
+  startTime: string;
+  endTime: string;
+}
+
+export default function TimetablePage(): JSX.Element {
+  const { user } = useAuth();
+  const convex = useConvex();
+  const schoolId = user?.schoolId || '';
+
+  // Get current admin to fetch school information
+  const currentAdmin = useQuery(
+    api.schoolAdmins.getByEmail,
+    user?.email ? { email: user.email } : 'skip'
+  );
+
+  const schoolCreationRequests = useQuery(
+    api.schoolCreationRequests.getByAdmin,
+    currentAdmin ? { schoolAdminId: currentAdmin._id } : 'skip'
+  );
+
+  const approvedSchool = schoolCreationRequests?.find((req: { status: string }) => req.status === 'approved');
+
+  // Queries
+  const timetables = useQuery(
+    api.timetables.getTimetables,
+    schoolId ? { schoolId } : 'skip'
+  ) as Timetable[] | undefined;
+
+  const classes = useQuery(
+    api.classes.getClassesBySchool,
+    schoolId ? { schoolId } : 'skip'
+  ) as Class[] | undefined;
+
+  const teachers = useQuery(
+    api.teachers.getTeachersBySchool,
+    schoolId ? { schoolId } : 'skip'
+  ) as Teacher[] | undefined;
+
+  // State
+  const [searchQuery, setSearchQuery] = useState<string>('');
+  const [selectedClass, setSelectedClass] = useState<string>('all');
+  const [selectedTimetable, setSelectedTimetable] = useState<Id<'timetables'> | null>(null);
+  const [exportingClass, setExportingClass] = useState<Id<'timetables'> | null>(null);
+  const [exportingTeacher, setExportingTeacher] = useState<Id<'teachers'> | null>(null);
+  const [exportingMaster, setExportingMaster] = useState<boolean>(false);
+
+  // Dialogs
+  const [showAddDialog, setShowAddDialog] = useState<boolean>(false);
+  const [showDeleteDialog, setShowDeleteDialog] = useState<boolean>(false);
+  const [showBulkDeleteDialog, setShowBulkDeleteDialog] = useState<boolean>(false);
+
+  // Selected rows for bulk operations
+  const [selectedRows, setSelectedRows] = useState<Record<string, boolean>>({});
+
+  // Filter timetables
+  const filteredTimetables = useMemo(() => {
+    if (!timetables) return [];
+
+    return timetables.filter((timetable) => {
+      const matchesSearch = 
+        timetable.className.toLowerCase().includes(searchQuery.toLowerCase());
+
+      const matchesClass = selectedClass === 'all' || timetable.classId === selectedClass;
+
+      return matchesSearch && matchesClass;
+    });
+  }, [timetables, searchQuery, selectedClass]);
+
+  // Group timetables by class (should be one timetable per class now)
+  const groupedTimetables = useMemo(() => {
+    const grouped: Record<string, Timetable[]> = {};
+    
+    filteredTimetables.forEach((timetable) => {
+      if (!grouped[timetable.classId]) {
+        grouped[timetable.classId] = [];
+      }
+      grouped[timetable.classId].push(timetable);
+    });
+
+    return grouped;
+  }, [filteredTimetables]);
+
+  // Get selected timetable IDs for bulk operations
+  const selectedTimetableIds = useMemo(() => {
+    return Object.keys(selectedRows).filter(id => selectedRows[id]) as Id<'timetables'>[];
+  }, [selectedRows]);
+
+  // Get classes that don't have timetables yet
+  const availableClasses = useMemo(() => {
+    const classesWithTimetables = new Set(
+      timetables?.map(t => t.classId) || []
+    );
+    return classes?.filter(c => 
+      c.status === 'active' && !classesWithTimetables.has(c._id)
+    ) || [];
+  }, [classes, timetables]);
+
+  // Export class timetable handler
+  const handleExportClassTimetable = useCallback(async (timetableId: Id<'timetables'>) => {
+    setExportingClass(timetableId);
+    
+    try {
+      // Fetch timetable data using Convex client
+      const timetableData = await convex.query(api.timetables.getTimetable, { timetableId });
+      
+      if (!timetableData) {
+        toast.error('Timetable not found');
+        return;
+      }
+
+      const { timetable, periodsByDay } = timetableData;
+
+      // Flatten periods from all days
+      const periods: Period[] = [];
+      Object.values(periodsByDay as Record<string, Period[]>).forEach(dayPeriods => {
+        periods.push(...dayPeriods);
+      });
+
+      // Fetch assignments using Convex client
+      const assignments = await convex.query(api.timetables.getAssignments, { timetableId }) as Assignment[];
+
+      // Prepare data for export
+      const exportData = {
+        className: timetable.className,
+        schoolName: approvedSchool?.schoolName,
+        periods: periods.map(p => ({
+          periodName: p.periodName,
+          startTime: p.startTime,
+          endTime: p.endTime,
+          periodType: p.periodType,
+          day: p.day,
+        })),
+        assignments: assignments.map(a => ({
+          periodId: `${periods.find(p => p._id === a.periodId)?.periodName}_${a.day}`,
+          subjectName: a.subjectName,
+          teacherName: a.teacherName,
+          subjectColor: a.subjectColor,
+          day: a.day,
+        })),
+      };
+
+      exportClassTimetablePDF(exportData);
+      toast.success(`${timetable.className} timetable exported successfully`);
+    } catch (error) {
+      console.error('Export error:', error);
+      toast.error('Failed to export timetable');
+    } finally {
+      setExportingClass(null);
+    }
+  }, [convex, approvedSchool]);
+
+  // Export teacher schedule handler
+  const handleExportTeacherSchedule = useCallback(async (teacherId: Id<'teachers'>) => {
+    setExportingTeacher(teacherId);
+    
+    try {
+      const teacher = teachers?.find(t => t._id === teacherId);
+      if (!teacher) {
+        toast.error('Teacher not found');
+        return;
+      }
+
+      // Fetch all assignments for this teacher using Convex client
+      const assignments = await convex.query(api.timetableAssignments.getAssignmentsByTeacher, {
+        schoolId,
+        teacherId: teacher.teacherId
+      }) as Assignment[];
+
+      if (assignments.length === 0) {
+        toast.error('No assignments found for this teacher');
+        return;
+      }
+
+      // Prepare data for export
+      const exportData = {
+        teacherName: `${teacher.firstName} ${teacher.lastName}`,
+        schoolName: approvedSchool?.schoolName,
+        assignments: assignments.map(a => ({
+          periodId: a.periodId,
+          subjectName: a.subjectName,
+          teacherName: a.teacherName,
+          className: a.className,
+          day: a.day,
+          startTime: a.startTime,
+          endTime: a.endTime,
+        })),
+      };
+
+      exportTeacherSchedulePDF(exportData);
+      toast.success(`${teacher.firstName} ${teacher.lastName}'s schedule exported successfully`);
+    } catch (error) {
+      console.error('Export error:', error);
+      toast.error('Failed to export teacher schedule');
+    } finally {
+      setExportingTeacher(null);
+    }
+  }, [convex, teachers, schoolId, approvedSchool]);
+
+  // Export master timetable handler
+  const handleExportMasterTimetable = useCallback(async () => {
+    setExportingMaster(true);
+    
+    try {
+      if (!filteredTimetables.length) {
+        toast.error('No timetables to export');
+        return;
+      }
+
+      // Fetch all timetables data
+      const timetablesData = [];
+      
+      for (const timetable of filteredTimetables) {
+        // Fetch timetable data using Convex client
+        const timetableData = await convex.query(api.timetables.getTimetable, { 
+          timetableId: timetable._id 
+        });
+        
+        if (!timetableData) {
+          continue;
+        }
+
+        const { timetable: timetableInfo, periodsByDay } = timetableData;
+
+        // Flatten periods from all days
+        const periods: Period[] = [];
+        Object.values(periodsByDay as Record<string, Period[]>).forEach(dayPeriods => {
+          periods.push(...dayPeriods);
+        });
+
+        // Fetch assignments using Convex client
+        const assignments = await convex.query(api.timetables.getAssignments, { 
+          timetableId: timetable._id 
+        }) as Assignment[];
+
+        // Prepare data for export
+        timetablesData.push({
+          className: timetableInfo.className,
+          schoolName: approvedSchool?.schoolName,
+          periods: periods.map(p => ({
+            periodName: p.periodName,
+            startTime: p.startTime,
+            endTime: p.endTime,
+            periodType: p.periodType,
+            day: p.day,
+          })),
+          assignments: assignments.map(a => ({
+            periodId: `${periods.find(p => p._id === a.periodId)?.periodName}_${a.day}`,
+            subjectName: a.subjectName,
+            teacherName: a.teacherName,
+            subjectColor: a.subjectColor,
+            day: a.day,
+          })),
+        });
+      }
+
+      exportMasterTimetablePDF(
+        timetablesData,
+        approvedSchool?.schoolName
+      );
+      
+      toast.success('Master timetable exported successfully');
+    } catch (error) {
+      console.error('Export error:', error);
+      toast.error('Failed to export master timetable');
+    } finally {
+      setExportingMaster(false);
+    }
+  }, [convex, filteredTimetables, approvedSchool]);
+
+  const handleDeleteClick = useCallback((timetableId: Id<'timetables'>): void => {
+    setSelectedTimetable(timetableId);
+    setShowDeleteDialog(true);
+  }, []);
+
+  const handleBulkDelete = useCallback((): void => {
+    if (selectedTimetableIds.length === 0) {
+      toast.error('No timetables selected');
+      return;
+    }
+    setShowBulkDeleteDialog(true);
+  }, [selectedTimetableIds]);
+
+  const activeClasses = useMemo(() => {
+    return classes?.filter(c => c.status === 'active') || [];
+  }, [classes]);
+
+  const activeTeachers = useMemo(() => {
+    return teachers?.filter(t => t.status === 'active') || [];
+  }, [teachers]);
+
+  if (!user || !approvedSchool) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-center">
+          <Clock className="mx-auto h-12 w-12 text-muted-foreground" />
+          <p className="mt-4 text-lg font-medium">Loading timetable...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div>
+            <h2 className="text-3xl font-bold tracking-tight">Timetable Management</h2>
+            <p className="text-muted-foreground">
+              Manage class schedules and teacher assignments
+            </p>
+          </div>
+          <Button onClick={() => setShowAddDialog(true)} disabled={availableClasses.length === 0}>
+            <Plus className="mr-2 h-4 w-4" />
+            Create Timetable
+          </Button>
+        </div>
+
+        {/* Filters and Actions */}
+        <Card className="p-4">
+          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            {/* Search */}
+            <div className="relative flex-1 max-w-sm">
+              <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                placeholder="Search by class..."
+                value={searchQuery}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearchQuery(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+
+            {/* Filters */}
+            <div className="flex flex-wrap gap-2">
+              <Select value={selectedClass} onValueChange={setSelectedClass}>
+                <SelectTrigger className="w-[180px]">
+                  <Filter className="mr-2 h-4 w-4" />
+                  <SelectValue placeholder="Filter by class" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">All Classes</SelectItem>
+                  {activeClasses.map((cls) => (
+                    <SelectItem key={cls._id} value={cls._id}>
+                      {cls.className}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+
+              {/* Export Dropdown */}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" disabled={exportingMaster}>
+                    <Download className="mr-2 h-4 w-4" />
+                    {exportingMaster ? 'Exporting...' : 'Export'}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end" className="w-56">
+                  <DropdownMenuLabel>Export Options</DropdownMenuLabel>
+                  <DropdownMenuSeparator />
+                  
+                  <DropdownMenuItem 
+                    onClick={handleExportMasterTimetable}
+                    disabled={filteredTimetables.length === 0 || exportingMaster}
+                  >
+                    <FileText className="mr-2 h-4 w-4" />
+                    Master Timetable (All Classes)
+                  </DropdownMenuItem>
+
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="text-xs text-muted-foreground">
+                    Individual Class
+                  </DropdownMenuLabel>
+                  
+                  {filteredTimetables.length === 0 ? (
+                    <DropdownMenuItem disabled>
+                      <GraduationCap className="mr-2 h-4 w-4" />
+                      No classes available
+                    </DropdownMenuItem>
+                  ) : (
+                    filteredTimetables.map((timetable) => (
+                      <DropdownMenuItem
+                        key={timetable._id}
+                        onClick={() => handleExportClassTimetable(timetable._id)}
+                        disabled={exportingClass === timetable._id}
+                      >
+                        <GraduationCap className="mr-2 h-4 w-4" />
+                        {exportingClass === timetable._id ? 'Exporting...' : timetable.className}
+                      </DropdownMenuItem>
+                    ))
+                  )}
+
+                  <DropdownMenuSeparator />
+                  <DropdownMenuLabel className="text-xs text-muted-foreground">
+                    Teacher Schedule
+                  </DropdownMenuLabel>
+                  
+                  {activeTeachers.length === 0 ? (
+                    <DropdownMenuItem disabled>
+                      <Users className="mr-2 h-4 w-4" />
+                      No teachers available
+                    </DropdownMenuItem>
+                  ) : (
+                    activeTeachers.slice(0, 10).map((teacher) => (
+                      <DropdownMenuItem
+                        key={teacher._id}
+                        onClick={() => handleExportTeacherSchedule(teacher._id)}
+                        disabled={exportingTeacher === teacher._id}
+                      >
+                        <Users className="mr-2 h-4 w-4" />
+                        {exportingTeacher === teacher._id 
+                          ? 'Exporting...' 
+                          : `${teacher.firstName} ${teacher.lastName}`
+                        }
+                      </DropdownMenuItem>
+                    ))
+                  )}
+                  
+                  {activeTeachers.length > 10 && (
+                    <DropdownMenuItem disabled className="text-xs text-muted-foreground">
+                      + {activeTeachers.length - 10} more teachers...
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
+
+              {/* Bulk Delete */}
+              {selectedTimetableIds.length > 0 && (
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={handleBulkDelete}
+                >
+                  <Trash2 className="mr-2 h-4 w-4" />
+                  Delete Selected ({selectedTimetableIds.length})
+                </Button>
+              )}
+            </div>
+          </div>
+        </Card>
+
+        {/* Timetable View */}
+        {Object.keys(groupedTimetables).length === 0 ? (
+          <Card className="flex h-[400px] flex-col items-center justify-center p-8">
+            <Clock className="h-12 w-12 text-muted-foreground" />
+            <h3 className="mt-4 text-lg font-semibold">No timetables created yet</h3>
+            <p className="mt-2 text-center text-sm text-muted-foreground">
+              Get started by creating your first class timetable
+            </p>
+            <Button 
+              className="mt-4" 
+              onClick={() => setShowAddDialog(true)}
+              disabled={availableClasses.length === 0}
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Create Timetable
+            </Button>
+            {availableClasses.length === 0 && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                All classes already have timetables
+              </p>
+            )}
+          </Card>
+        ) : (
+          <div className="space-y-6">
+            {Object.entries(groupedTimetables).map(([classId, classTimetables]) => {
+              const className = classTimetables[0]?.className || 'Unknown Class';
+              const timetableId = classTimetables[0]?._id;
+              
+              return (
+                <Card key={classId} className="p-6">
+                  <div className="flex items-center justify-between mb-4">
+                    <h3 className="text-xl font-semibold">{className}</h3>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => timetableId && handleExportClassTimetable(timetableId)}
+                      disabled={exportingClass === timetableId}
+                    >
+                      <Download className="mr-2 h-4 w-4" />
+                      {exportingClass === timetableId ? 'Exporting...' : 'Export PDF'}
+                    </Button>
+                  </div>
+                  
+                  <TimetableView
+                    timetables={classTimetables}
+                    classId={classId}
+                    className={className}
+                    schoolId={schoolId}
+                    teachers={activeTeachers}
+                    onDelete={handleDeleteClick}
+                  />
+                </Card>
+              );
+            })}
+          </div>
+        )}
+
+        {/* Dialogs */}
+        <AddTimetableDialog
+          open={showAddDialog}
+          onOpenChange={setShowAddDialog}
+          schoolId={schoolId}
+          classes={availableClasses}
+        />
+
+        <DeleteTimetableDialog
+          open={showDeleteDialog}
+          onOpenChange={setShowDeleteDialog}
+          timetableId={selectedTimetable}
+        />
+
+        <BulkDeleteTimetablesDialog
+          open={showBulkDeleteDialog}
+          onOpenChange={setShowBulkDeleteDialog}
+          timetableIds={selectedTimetableIds}
+          onSuccess={() => setSelectedRows({})}
+        />
+      </div>
+  );
+}

--- a/src/components/school-admin/app-sidebar.tsx
+++ b/src/components/school-admin/app-sidebar.tsx
@@ -25,6 +25,7 @@ import {
   Users,
   BookOpen,
   Calendar,
+  Clock,
 } from 'lucide-react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
@@ -77,6 +78,11 @@ const menuItems = [
     title: 'Subjects',
     icon: BookOpen,
     url: '/school-admin/subjects',
+  },
+  {
+    title: 'Timetable',
+    icon: Clock,
+    url: '/school-admin/timetable',
   },
   {
     title: 'Subscription',

--- a/src/components/timetable/add-timetable-dialog.tsx
+++ b/src/components/timetable/add-timetable-dialog.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { JSX, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '../../../convex/_generated/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import { useAuth } from '@/hooks/useAuth';
+import type { Id } from '../../../convex/_generated/dataModel';
+
+interface AddTimetableDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  schoolId: string;
+  classes: Array<{
+    _id: Id<'classes'>;
+    className: string;
+  }>;
+}
+
+export function AddTimetableDialog({
+  open,
+  onOpenChange,
+  schoolId,
+  classes,
+}: AddTimetableDialogProps): JSX.Element {
+  const { user } = useAuth();
+  const createTimetable = useMutation(api.timetables.createTimetable);
+
+  const [selectedClass, setSelectedClass] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+
+    if (!selectedClass) {
+      toast.error('Please select a class');
+      return;
+    }
+
+    const selectedClassData = classes.find(c => c._id === selectedClass);
+    if (!selectedClassData) {
+      toast.error('Invalid class selected');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await createTimetable({
+        schoolId,
+        classId: selectedClass,
+        className: selectedClassData.className,
+        createdBy: user?.userId || '',
+      });
+
+      toast.success(`Weekly timetable created for ${selectedClassData.className}`);
+      
+      // Reset form
+      setSelectedClass('');
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error('Failed to create timetable');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Create Weekly Timetable</DialogTitle>
+            <DialogDescription>
+              Create a complete weekly timetable for a class. Default periods will be created for all weekdays (Monday-Friday).
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-4">
+            {/* Class Selection */}
+            <div className="grid gap-2">
+              <Label htmlFor="class">Class *</Label>
+              <Select value={selectedClass} onValueChange={setSelectedClass}>
+                <SelectTrigger id="class">
+                  <SelectValue placeholder="Select class" />
+                </SelectTrigger>
+                <SelectContent>
+                  {classes.map((cls) => (
+                    <SelectItem key={cls._id} value={cls._id}>
+                      {cls.className}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Info about default schedule */}
+            <div className="rounded-lg bg-muted p-3 text-sm">
+              <p className="font-medium mb-2">Default Schedule (Mon-Fri):</p>
+              <ul className="space-y-1 text-xs text-muted-foreground">
+                <li>• Assembly: 7:30 AM - 8:00 AM</li>
+                <li>• Period 1: 8:00 AM - 9:10 AM</li>
+                <li>• Period 2: 9:10 AM - 10:20 AM</li>
+                <li>• Break: 10:20 AM - 10:40 AM</li>
+                <li>• Period 3: 10:45 AM - 11:55 AM</li>
+                <li>• Period 4: 11:55 AM - 1:05 PM</li>
+                <li>• Lunch: 1:05 PM - 1:35 PM</li>
+                <li>• Period 5: 1:35 PM - 2:45 PM</li>
+                <li>• Period 6: 2:45 PM - 3:55 PM</li>
+                <li>• Closing: 3:55 PM - 4:00 PM</li>
+              </ul>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Create Weekly Timetable
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/timetable/assign-teacher-dialog.tsx
+++ b/src/components/timetable/assign-teacher-dialog.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useState, useMemo, JSX } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '../../../convex/_generated/api';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { toast } from 'sonner';
+import { Loader2, AlertCircle } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import type { Id } from '../../../convex/_generated/dataModel';
+
+type Day = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday';
+
+interface Period {
+  _id: Id<'periods'>;
+  periodName: string;
+  startTime: string;
+  endTime: string;
+}
+
+interface Teacher {
+  _id: Id<'teachers'>;
+  teacherId: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface Subject {
+  status: string;
+  _id: Id<'subjects'>;
+  subjectCode: string;
+  subjectName: string;
+}
+
+interface AssignTeacherDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  period: Period;
+  timetableId: Id<'timetables'>;
+  classId: string;
+  className: string;
+  day: Day;
+  schoolId: string;
+  teachers: Teacher[];
+}
+
+export function AssignTeacherDialog({
+  open,
+  onOpenChange,
+  period,
+  timetableId,
+  classId,
+  className,
+  day,
+  schoolId,
+  teachers,
+}: AssignTeacherDialogProps): JSX.Element {
+  const assignTeacher = useMutation(api.timetables.assignTeacherToSlot);
+  
+  // Get subjects
+  const subjects = useQuery(
+    api.subjects.getSubjectsBySchool,
+    schoolId ? { schoolId } : 'skip'
+  ) as Subject[] | undefined;
+
+  const [selectedTeacher, setSelectedTeacher] = useState<string>('');
+  const [selectedSubject, setSelectedSubject] = useState<string>('');
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [conflictError, setConflictError] = useState<string>('');
+
+  const activeSubjects = useMemo(() => {
+    return subjects?.filter(s => s.status === 'active') || [];
+  }, [subjects]);
+
+  const handleSubmit = async (e: React.FormEvent): Promise<void> => {
+    e.preventDefault();
+    setConflictError('');
+
+    if (!selectedTeacher || !selectedSubject) {
+      toast.error('Please select both teacher and subject');
+      return;
+    }
+
+    const teacher = teachers.find(t => t._id === selectedTeacher);
+    const subject = activeSubjects.find(s => s._id === selectedSubject);
+
+    if (!teacher || !subject) {
+      toast.error('Invalid teacher or subject selected');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      await assignTeacher({
+        timetableId,
+        periodId: period._id,
+        teacherId: teacher.teacherId,
+        teacherName: `${teacher.firstName} ${teacher.lastName}`,
+        subjectId: subject._id,
+        subjectName: subject.subjectName,
+        classId,
+        className,
+        schoolId,
+        day,
+        startTime: period.startTime,
+        endTime: period.endTime,
+      });
+
+      toast.success(`${teacher.firstName} ${teacher.lastName} assigned to ${subject.subjectName}`);
+      
+      // Reset form
+      setSelectedTeacher('');
+      setSelectedSubject('');
+      onOpenChange(false);
+    } catch (error) {
+      if (error instanceof Error) {
+        setConflictError(error.message);
+        toast.error(error.message);
+      } else {
+        toast.error('Failed to assign teacher');
+      }
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[500px]">
+        <form onSubmit={handleSubmit}>
+          <DialogHeader>
+            <DialogTitle>Assign Teacher & Subject</DialogTitle>
+            <DialogDescription>
+              Assign a teacher and subject to {period.periodName} ({period.startTime} - {period.endTime}) for {className} on {day}
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="grid gap-4 py-4">
+            {conflictError && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{conflictError}</AlertDescription>
+              </Alert>
+            )}
+
+            {/* Teacher Selection */}
+            <div className="grid gap-2">
+              <Label htmlFor="teacher">Teacher *</Label>
+              <Select value={selectedTeacher} onValueChange={setSelectedTeacher}>
+                <SelectTrigger id="teacher">
+                  <SelectValue placeholder="Select teacher" />
+                </SelectTrigger>
+                <SelectContent>
+                  {teachers.map((teacher) => (
+                    <SelectItem key={teacher._id} value={teacher._id}>
+                      {teacher.firstName} {teacher.lastName} ({teacher.teacherId})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Subject Selection */}
+            <div className="grid gap-2">
+              <Label htmlFor="subject">Subject *</Label>
+              <Select value={selectedSubject} onValueChange={setSelectedSubject}>
+                <SelectTrigger id="subject">
+                  <SelectValue placeholder="Select subject" />
+                </SelectTrigger>
+                <SelectContent>
+                  {activeSubjects.map((subject) => (
+                    <SelectItem key={subject._id} value={subject._id}>
+                      {subject.subjectName} ({subject.subjectCode})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            {/* Period Info */}
+            <div className="rounded-lg bg-muted p-3 text-sm">
+              <p className="font-medium mb-2">Assignment Details:</p>
+              <ul className="space-y-1 text-xs text-muted-foreground">
+                <li>• Class: {className}</li>
+                <li>• Day: {day.charAt(0).toUpperCase() + day.slice(1)}</li>
+                <li>• Period: {period.periodName}</li>
+                <li>• Time: {period.startTime} - {period.endTime}</li>
+              </ul>
+            </div>
+          </div>
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => onOpenChange(false)}
+              disabled={isLoading}
+            >
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isLoading}>
+              {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Assign Teacher
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/timetable/bulk-delete-timetables-dialog.tsx
+++ b/src/components/timetable/bulk-delete-timetables-dialog.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { JSX, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '../../../convex/_generated/api';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import type { Id } from '../../../convex/_generated/dataModel';
+
+interface BulkDeleteTimetablesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  timetableIds: Id<'timetables'>[];
+  onSuccess?: () => void;
+}
+
+export function BulkDeleteTimetablesDialog({
+  open,
+  onOpenChange,
+  timetableIds,
+  onSuccess,
+}: BulkDeleteTimetablesDialogProps): JSX.Element {
+  const bulkDeleteTimetables = useMutation(api.timetables.bulkDeleteTimetables);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const handleBulkDelete = async (): Promise<void> => {
+    if (timetableIds.length === 0) return;
+
+    setIsLoading(true);
+
+    try {
+      await bulkDeleteTimetables({ timetableIds });
+      toast.success(`${timetableIds.length} timetable(s) deleted successfully`);
+      onSuccess?.();
+      onOpenChange(false);
+    } catch (error) {
+      toast.error('Failed to delete timetables');
+      console.error('Bulk delete error:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Multiple Timetables</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete {timetableIds.length} timetable(s)? This will also remove all associated periods and teacher assignments. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleBulkDelete}
+            disabled={isLoading}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Delete {timetableIds.length} Timetable(s)
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/timetable/delete-timetable-dialog.tsx
+++ b/src/components/timetable/delete-timetable-dialog.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { JSX, useState } from 'react';
+import { useMutation } from 'convex/react';
+import { api } from '../../../convex/_generated/api';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { toast } from 'sonner';
+import { Loader2 } from 'lucide-react';
+import type { Id } from '../../../convex/_generated/dataModel';
+
+interface DeleteTimetableDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  timetableId: Id<'timetables'> | null;
+}
+
+export function DeleteTimetableDialog({
+  open,
+  onOpenChange,
+  timetableId,
+}: DeleteTimetableDialogProps): JSX.Element {
+  const deleteTimetable = useMutation(api.timetables.deleteTimetable);
+  const [isLoading, setIsLoading] = useState<boolean>(false);
+
+  const handleDelete = async (): Promise<void> => {
+    if (!timetableId) return;
+
+    setIsLoading(true);
+
+    try {
+      await deleteTimetable({ timetableId });
+      toast.success('Timetable deleted successfully');
+      onOpenChange(false);
+    } catch (error) {
+      toast.error('Failed to delete timetable');
+      console.error('Delete timetable error:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Delete Timetable</AlertDialogTitle>
+          <AlertDialogDescription>
+            Are you sure you want to delete this timetable? This will also remove all periods and teacher assignments. This action cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleDelete}
+            disabled={isLoading}
+            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+          >
+            {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/src/components/timetable/timetable-view.tsx
+++ b/src/components/timetable/timetable-view.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+import { useState, useMemo, JSX } from 'react';
+import { useQuery, useMutation } from 'convex/react';
+import { api } from '../../../convex/_generated/api';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { Trash2, Edit2, Check, X, UserPlus } from 'lucide-react';
+import { toast } from 'sonner';
+import type { Id } from '../../../convex/_generated/dataModel';
+import { AssignTeacherDialog } from './assign-teacher-dialog';
+import { convertTo12Hour } from '@/lib/timeUtils';
+
+type Day = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday';
+
+interface Timetable {
+  _id: Id<'timetables'>;
+  classId: string;
+  className: string;
+  schoolId: string;
+}
+
+interface Period {
+  _id: Id<'periods'>;
+  timetableId: Id<'timetables'>;
+  day: Day;
+  periodName: string;
+  startTime: string;
+  endTime: string;
+  periodType: 'class' | 'break';
+  duration: number;
+}
+
+interface Assignment {
+  _id: Id<'timetableAssignments'>;
+  periodId: Id<'periods'>;
+  teacherId: string;
+  teacherName: string;
+  subjectId: string;
+  subjectName: string;
+}
+
+interface Teacher {
+  _id: Id<'teachers'>;
+  teacherId: string;
+  firstName: string;
+  lastName: string;
+}
+
+interface TimetableViewProps {
+  timetables: Timetable[];
+  classId: string;
+  className: string;
+  schoolId: string;
+  teachers: Teacher[];
+  onDelete: (timetableId: Id<'timetables'>) => void;
+}
+
+export function TimetableView({
+  timetables,
+  classId,
+  className,
+  schoolId,
+  teachers,
+  onDelete,
+}: TimetableViewProps): JSX.Element {
+  const updatePeriod = useMutation(api.timetables.updatePeriod);
+  const removeAssignment = useMutation(api.timetables.removeAssignment);
+
+  const [editingPeriod, setEditingPeriod] = useState<Id<'periods'> | null>(null);
+  const [editStartTime, setEditStartTime] = useState<string>('');
+  const [editEndTime, setEditEndTime] = useState<string>('');
+  const [showAssignDialog, setShowAssignDialog] = useState<boolean>(false);
+  const [selectedPeriod, setSelectedPeriod] = useState<Period | null>(null);
+  const [selectedTimetableId, setSelectedTimetableId] = useState<Id<'timetables'> | null>(null);
+  const [selectedDay, setSelectedDay] = useState<Day | null>(null);
+
+  // Get the first (and only) timetable for this class
+  const timetable = timetables[0];
+
+  // Load periods and assignments
+  const timetableDataResponse = useQuery(
+    api.timetables.getTimetable,
+    timetable ? { timetableId: timetable._id } : 'skip'
+  );
+  const assignmentsData = useQuery(
+    api.timetables.getAssignments,
+    timetable ? { timetableId: timetable._id } : 'skip'
+  );
+
+  const periodsByDay = timetableDataResponse?.periodsByDay;
+  const assignments = assignmentsData || [];
+
+  // Get unique period names (rows) from Monday's schedule
+  const periodRows = useMemo(() => {
+    if (!periodsByDay?.monday) return [];
+    
+    // Sort by start time
+    return [...periodsByDay.monday].sort((a, b) => {
+      const aTime = parseInt(a.startTime.replace(':', ''));
+      const bTime = parseInt(b.startTime.replace(':', ''));
+      return aTime - bTime;
+    });
+  }, [periodsByDay]);
+
+  // Days of week in order
+  const daysOfWeek: Day[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
+
+  const handleEditPeriod = (period: Period): void => {
+    setEditingPeriod(period._id);
+    setEditStartTime(period.startTime);
+    setEditEndTime(period.endTime);
+  };
+
+  const handleSaveEdit = async (): Promise<void> => {
+    if (!editingPeriod) return;
+
+    try {
+      await updatePeriod({
+        periodId: editingPeriod,
+        startTime: editStartTime,
+        endTime: editEndTime,
+      });
+
+      toast.success('Period time updated successfully');
+      setEditingPeriod(null);
+    } catch (error) {
+      toast.error('Failed to update period time');
+      console.error('Update period error:', error);
+    }
+  };
+
+  const handleCancelEdit = (): void => {
+    setEditingPeriod(null);
+    setEditStartTime('');
+    setEditEndTime('');
+  };
+
+  const handleAssignTeacher = (period: Period, timetableId: Id<'timetables'>, day: Day): void => {
+    setSelectedPeriod(period);
+    setSelectedTimetableId(timetableId);
+    setSelectedDay(day);
+    setShowAssignDialog(true);
+  };
+
+  const handleRemoveAssignment = async (periodId: Id<'periods'>): Promise<void> => {
+    try {
+      await removeAssignment({ periodId });
+      toast.success('Teacher assignment removed');
+    } catch (error) {
+      toast.error('Failed to remove assignment');
+      console.error('Remove assignment error:', error);
+    }
+  };
+
+  const getAssignmentForPeriod = (periodId: Id<'periods'>): Assignment | undefined => {
+    return assignments.find(a => a.periodId === periodId);
+  };
+
+  const getPeriodForDayAndName = (day: Day, periodName: string): Period | undefined => {
+    return periodsByDay?.[day]?.find(p => p.periodName === periodName);
+  };
+
+  if (!timetable || !periodsByDay) {
+    return (
+      <div className="flex items-center justify-center p-8">
+        <p className="text-muted-foreground">Loading timetable...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h4 className="text-lg font-medium">Weekly Schedule</h4>
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => onDelete(timetable._id)}
+        >
+          <Trash2 className="h-4 w-4 text-destructive mr-2" />
+          Delete Timetable
+        </Button>
+      </div>
+
+      <div className="rounded-md border overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-[200px] font-bold">Period / Time</TableHead>
+              {daysOfWeek.map((day) => (
+                <TableHead key={day} className="text-center font-bold capitalize min-w-[180px]">
+                  {day}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {periodRows.map((mondayPeriod) => {
+              const isBreak = mondayPeriod.periodType === 'break';
+              const isEditing = editingPeriod === mondayPeriod._id;
+
+              return (
+                <TableRow key={mondayPeriod.periodName}>
+                  {/* Period Name & Time Column */}
+                  <TableCell className="font-medium">
+                    <div className="flex flex-col gap-1">
+                      <div className="flex items-center gap-2">
+                        <span>{mondayPeriod.periodName}</span>
+                        {isBreak && (
+                          <Badge variant="outline" className="text-xs">
+                            Break
+                          </Badge>
+                        )}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {isEditing ? (
+                          <div className="flex flex-col gap-1">
+                            <Input
+                              type="time"
+                              value={editStartTime}
+                              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEditStartTime(e.target.value)}
+                              className="h-7 w-24 text-xs"
+                            />
+                            <Input
+                              type="time"
+                              value={editEndTime}
+                              onChange={(e: React.ChangeEvent<HTMLInputElement>) => setEditEndTime(e.target.value)}
+                              className="h-7 w-24 text-xs"
+                            />
+                            <div className="flex gap-1">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={handleSaveEdit}
+                                className="h-6 px-2"
+                              >
+                                <Check className="h-3 w-3 text-green-600" />
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={handleCancelEdit}
+                                className="h-6 px-2"
+                              >
+                                <X className="h-3 w-3 text-destructive" />
+                              </Button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-2">
+                            <span>{convertTo12Hour(mondayPeriod.startTime)} - {convertTo12Hour(mondayPeriod.endTime)}</span>
+                            <Button
+                              variant="ghost"
+                              size="sm"
+                              onClick={() => handleEditPeriod(mondayPeriod)}
+                              className="h-5 w-5 p-0"
+                            >
+                              <Edit2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  </TableCell>
+
+                  {/* Day Columns */}
+                  {daysOfWeek.map((day) => {
+                    const period = getPeriodForDayAndName(day, mondayPeriod.periodName);
+                    if (!period) {
+                      return <TableCell key={day} className="text-center">-</TableCell>;
+                    }
+
+                    const assignment = getAssignmentForPeriod(period._id);
+
+                    if (isBreak) {
+                      return (
+                        <TableCell key={day} className="text-center bg-muted/30">
+                          <span className="text-xs text-muted-foreground">-</span>
+                        </TableCell>
+                      );
+                    }
+
+                    return (
+                      <TableCell key={day} className="p-2">
+                        {assignment ? (
+                          <div className="flex flex-col gap-1">
+                            <div className="text-sm font-medium">{assignment.subjectName}</div>
+                            <div className="text-xs text-muted-foreground">{assignment.teacherName}</div>
+                            <div className="flex gap-1 mt-1">
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleAssignTeacher(period, timetable._id, day)}
+                                className="h-6 text-xs px-2"
+                              >
+                                Edit
+                              </Button>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                onClick={() => handleRemoveAssignment(period._id)}
+                                className="h-6 px-2"
+                              >
+                                <X className="h-3 w-3 text-destructive" />
+                              </Button>
+                            </div>
+                          </div>
+                        ) : (
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => handleAssignTeacher(period, timetable._id, day)}
+                            className="w-full h-auto py-2"
+                          >
+                            <UserPlus className="h-4 w-4 mr-2" />
+                            Assign
+                          </Button>
+                        )}
+                      </TableCell>
+                    );
+                  })}
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </div>
+
+      {/* Assign Teacher Dialog */}
+      {selectedPeriod && selectedTimetableId && selectedDay && (
+        <AssignTeacherDialog
+          open={showAssignDialog}
+          onOpenChange={setShowAssignDialog}
+          period={selectedPeriod}
+          timetableId={selectedTimetableId}
+          classId={classId}
+          className={className}
+          day={selectedDay}
+          schoolId={schoolId}
+          teachers={teachers}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/lib/timeUtils.ts
+++ b/src/lib/timeUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * Time utility functions for converting between 24-hour and 12-hour formats
+ */
+
+/**
+ * Converts 24-hour time format to 12-hour format with AM/PM
+ * @param time24 - Time in 24-hour format (e.g., "14:30")
+ * @returns Time in 12-hour format (e.g., "2:30 PM")
+ */
+export function convertTo12Hour(time24: string): string {
+  const [hours24, minutes] = time24.split(':').map(Number);
+  
+  if (isNaN(hours24) || isNaN(minutes)) {
+    return time24;
+  }
+  
+  const period = hours24 >= 12 ? 'PM' : 'AM';
+  const hours12 = hours24 % 12 || 12;
+  
+  return `${hours12}:${minutes.toString().padStart(2, '0')} ${period}`;
+}
+
+/**
+ * Converts 12-hour time format to 24-hour format
+ * @param time12 - Time in 12-hour format (e.g., "2:30 PM")
+ * @returns Time in 24-hour format (e.g., "14:30")
+ */
+export function convertTo24Hour(time12: string): string {
+  const match = time12.match(/^(\d{1,2}):(\d{2})\s*(AM|PM)$/i);
+  
+  if (!match) {
+    return time12;
+  }
+  
+  let [, hoursStr, minutesStr, period] = match;
+  let hours = parseInt(hoursStr);
+  const minutes = parseInt(minutesStr);
+  
+  if (period.toUpperCase() === 'PM' && hours !== 12) {
+    hours += 12;
+  } else if (period.toUpperCase() === 'AM' && hours === 12) {
+    hours = 0;
+  }
+  
+  return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`;
+}
+
+/**
+ * Formats a time range in 12-hour format
+ * @param startTime24 - Start time in 24-hour format
+ * @param endTime24 - End time in 24-hour format
+ * @returns Formatted time range (e.g., "8:00 AM - 9:10 AM")
+ */
+export function formatTimeRange(startTime24: string, endTime24: string): string {
+  return `${convertTo12Hour(startTime24)} - ${convertTo12Hour(endTime24)}`;
+}

--- a/src/lib/timetable-export.ts
+++ b/src/lib/timetable-export.ts
@@ -1,0 +1,367 @@
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+import { convertTo12Hour } from './timeUtils';
+
+type Day = 'monday' | 'tuesday' | 'wednesday' | 'thursday' | 'friday';
+
+interface Period {
+  periodName: string;
+  startTime: string;
+  endTime: string;
+  periodType: 'class' | 'break';
+  day: Day;
+}
+
+interface Assignment {
+  periodId: string;
+  subjectName: string;
+  teacherName: string;
+  subjectColor?: string;
+  day: Day;
+}
+
+interface TimetableData {
+  className: string;
+  schoolName?: string;
+  periods: Period[];
+  assignments: Assignment[];
+}
+
+interface TeacherScheduleData {
+  teacherName: string;
+  schoolName?: string;
+  assignments: (Assignment & { className: string; startTime: string; endTime: string })[];
+}
+
+// Helper function to get color for PDF
+function hexToRGB(hex: string | undefined): [number, number, number] {
+  if (!hex) return [255, 255, 255];
+  const cleanHex = hex.replace('#', '');
+  const r = parseInt(cleanHex.substring(0, 2), 16);
+  const g = parseInt(cleanHex.substring(2, 4), 16);
+  const b = parseInt(cleanHex.substring(4, 6), 16);
+  return [r, g, b];
+}
+
+// Helper function to lighten RGB color
+function lightenRGB(rgb: [number, number, number], amount: number = 0.6): [number, number, number] {
+  return [
+    Math.round(rgb[0] + (255 - rgb[0]) * amount),
+    Math.round(rgb[1] + (255 - rgb[1]) * amount),
+    Math.round(rgb[2] + (255 - rgb[2]) * amount),
+  ];
+}
+
+// Export individual class timetable as PDF
+export function exportClassTimetablePDF(data: TimetableData): void {
+  const doc = new jsPDF('landscape');
+  
+  // Add header
+  doc.setFontSize(18);
+  doc.text(`${data.className} - Weekly Timetable`, 14, 15);
+  
+  if (data.schoolName) {
+    doc.setFontSize(10);
+    doc.text(String(data.schoolName), 14, 22);
+  }
+  
+  doc.setFontSize(9);
+  doc.text(`Generated: ${new Date().toLocaleString()}`, 14, 28);
+
+  // Group periods by period name and get unique periods
+  const periodsByName: Record<string, Period[]> = {};
+  data.periods.forEach(period => {
+    if (!periodsByName[period.periodName]) {
+      periodsByName[period.periodName] = [];
+    }
+    periodsByName[period.periodName].push(period);
+  });
+
+  // Get period order (sorted by start time from Monday)
+  const mondayPeriods = data.periods
+    .filter(p => p.day === 'monday')
+    .sort((a, b) => a.startTime.localeCompare(b.startTime));
+
+  // Prepare table data
+  const days: Day[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
+  const headers = ['Period / Time', ...days.map(d => d.charAt(0).toUpperCase() + d.slice(1))];
+  
+  const rows = mondayPeriods.map(mondayPeriod => {
+    const row: string[] = [
+      `${mondayPeriod.periodName}\n${convertTo12Hour(mondayPeriod.startTime)} - ${convertTo12Hour(mondayPeriod.endTime)}`
+    ];
+
+    days.forEach(day => {
+      const period = periodsByName[mondayPeriod.periodName]?.find(p => p.day === day);
+      if (!period) {
+        row.push('-');
+        return;
+      }
+
+      if (mondayPeriod.periodType === 'break') {
+        row.push('BREAK');
+        return;
+      }
+
+      const assignment = data.assignments.find(
+        a => a.periodId === period.periodName + '_' + day
+      );
+      
+      if (assignment) {
+        row.push(`${assignment.subjectName}\n${assignment.teacherName}`);
+      } else {
+        row.push('');
+      }
+    });
+
+    return row;
+  });
+
+  // Generate table
+  autoTable(doc, {
+    head: [headers],
+    body: rows,
+    startY: 35,
+    theme: 'grid',
+    styles: {
+      fontSize: 8,
+      cellPadding: 3,
+      valign: 'middle',
+      halign: 'center',
+    },
+    headStyles: {
+      fillColor: [37, 99, 235],
+      textColor: 255,
+      fontStyle: 'bold',
+      halign: 'center',
+    },
+    columnStyles: {
+      0: { cellWidth: 40, halign: 'left', fontStyle: 'bold' },
+    },
+    didParseCell: (cellData) => {
+      // Color code subject cells based on assignments
+      if (cellData.section === 'body' && cellData.column.index > 0) {
+        const rowIndex = cellData.row.index;
+        const dayIndex = cellData.column.index - 1;
+        
+        const period = mondayPeriods[rowIndex];
+        const day = days[dayIndex];
+        const assignment = data.assignments.find(
+          a => a.periodId === period.periodName + '_' + day
+        );
+
+        if (assignment?.subjectColor) {
+          const rgb = hexToRGB(assignment.subjectColor);
+          const lightRgb = lightenRGB(rgb);
+          cellData.cell.styles.fillColor = lightRgb as [number, number, number];
+        }
+      }
+    },
+  });
+
+  doc.save(`${data.className}_Timetable_${new Date().toISOString().split('T')[0]}.pdf`);
+}
+
+// Export teacher schedule as PDF
+export function exportTeacherSchedulePDF(data: TeacherScheduleData): void {
+  const doc = new jsPDF('landscape');
+  
+  // Add header
+  doc.setFontSize(18);
+  doc.text(`${data.teacherName} - Teaching Schedule`, 14, 15);
+  
+  if (data.schoolName) {
+    doc.setFontSize(10);
+    doc.text(String(data.schoolName), 14, 22);
+  }
+  
+  doc.setFontSize(9);
+  doc.text(`Generated: ${new Date().toLocaleString()}`, 14, 28);
+
+  // Group assignments by day
+  const days: Day[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
+  const headers = ['Time', ...days.map(d => d.charAt(0).toUpperCase() + d.slice(1))];
+  
+  // Get all unique time slots
+  const uniqueSlots = Array.from(
+    new Set(data.assignments.map(a => `${a.startTime}-${a.endTime}`))
+  ).sort((a, b) => a.split('-')[0].localeCompare(b.split('-')[0]));
+
+  const rows = uniqueSlots.map(slot => {
+    const [startTime, endTime] = slot.split('-');
+    const row: string[] = [
+      `${convertTo12Hour(startTime)} - ${convertTo12Hour(endTime)}`
+    ];
+
+    days.forEach(day => {
+      const assignment = data.assignments.find(
+        a => a.day === day && a.startTime === startTime && a.endTime === endTime
+      );
+      
+      if (assignment) {
+        row.push(`${assignment.subjectName}\n${assignment.className}`);
+      } else {
+        row.push('Free');
+      }
+    });
+
+    return row;
+  });
+
+  // Calculate summary
+  const totalPeriods = data.assignments.length;
+  const classesCount = new Set(data.assignments.map(a => a.className)).size;
+
+  // Add summary
+  doc.setFontSize(10);
+  doc.text(`Total Teaching Periods: ${totalPeriods}/week`, 14, doc.internal.pageSize.height - 10);
+  doc.text(`Classes Taught: ${classesCount}`, 100, doc.internal.pageSize.height - 10);
+
+  // Generate table
+  autoTable(doc, {
+    head: [headers],
+    body: rows,
+    startY: 35,
+    theme: 'grid',
+    styles: {
+      fontSize: 8,
+      cellPadding: 3,
+      valign: 'middle',
+      halign: 'center',
+    },
+    headStyles: {
+      fillColor: [37, 99, 235],
+      textColor: 255,
+      fontStyle: 'bold',
+      halign: 'center',
+    },
+    columnStyles: {
+      0: { cellWidth: 35, halign: 'left', fontStyle: 'bold' },
+    },
+  });
+
+  doc.save(`${data.teacherName}_Schedule_${new Date().toISOString().split('T')[0]}.pdf`);
+}
+
+// Export master timetable (all classes) as PDF - One page per class
+export function exportMasterTimetablePDF(
+  timetablesData: TimetableData[],
+  schoolName?: string
+): void {
+  const doc = new jsPDF('landscape');
+  
+  timetablesData.forEach((data, index) => {
+    // Add new page for each class (except the first one)
+    if (index > 0) {
+      doc.addPage();
+    }
+
+    // Add header
+    doc.setFontSize(18);
+    doc.text('Master Timetable - All Classes', 14, 15);
+    
+    doc.setFontSize(14);
+    doc.text(`Class: ${data.className}`, 14, 22);
+    
+    if (schoolName) {
+      doc.setFontSize(10);
+      doc.text(String(schoolName), 14, 28);
+    }
+    
+    doc.setFontSize(9);
+    doc.text(`Generated: ${new Date().toLocaleString()}`, 14, schoolName ? 33 : 28);
+
+    // Group periods by period name and get unique periods
+    const periodsByName: Record<string, Period[]> = {};
+    data.periods.forEach(period => {
+      if (!periodsByName[period.periodName]) {
+        periodsByName[period.periodName] = [];
+      }
+      periodsByName[period.periodName].push(period);
+    });
+
+    // Get period order (sorted by start time from Monday)
+    const mondayPeriods = data.periods
+      .filter(p => p.day === 'monday')
+      .sort((a, b) => a.startTime.localeCompare(b.startTime));
+
+    // Prepare table data
+    const days: Day[] = ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'];
+    const headers = ['Period / Time', ...days.map(d => d.charAt(0).toUpperCase() + d.slice(1))];
+    
+    const rows = mondayPeriods.map(mondayPeriod => {
+      const row: string[] = [
+        `${mondayPeriod.periodName}\n${convertTo12Hour(mondayPeriod.startTime)} - ${convertTo12Hour(mondayPeriod.endTime)}`
+      ];
+
+      days.forEach(day => {
+        const period = periodsByName[mondayPeriod.periodName]?.find(p => p.day === day);
+        if (!period) {
+          row.push('-');
+          return;
+        }
+
+        if (mondayPeriod.periodType === 'break') {
+          row.push('BREAK');
+          return;
+        }
+
+        const assignment = data.assignments.find(
+          a => a.periodId === period.periodName + '_' + day
+        );
+        
+        if (assignment) {
+          row.push(`${assignment.subjectName}\n${assignment.teacherName}`);
+        } else {
+          row.push('');
+        }
+      });
+
+      return row;
+    });
+
+    // Generate table for this class
+    autoTable(doc, {
+      head: [headers],
+      body: rows,
+      startY: schoolName ? 38 : 33,
+      theme: 'grid',
+      styles: {
+        fontSize: 8,
+        cellPadding: 3,
+        valign: 'middle',
+        halign: 'center',
+      },
+      headStyles: {
+        fillColor: [37, 99, 235],
+        textColor: 255,
+        fontStyle: 'bold',
+        halign: 'center',
+      },
+      columnStyles: {
+        0: { cellWidth: 40, halign: 'left', fontStyle: 'bold' },
+      },
+      didParseCell: (cellData) => {
+        // Color code subject cells based on assignments
+        if (cellData.section === 'body' && cellData.column.index > 0) {
+          const rowIndex = cellData.row.index;
+          const dayIndex = cellData.column.index - 1;
+          
+          const period = mondayPeriods[rowIndex];
+          const day = days[dayIndex];
+          const assignment = data.assignments.find(
+            a => a.periodId === period.periodName + '_' + day
+          );
+
+          if (assignment?.subjectColor) {
+            const rgb = hexToRGB(assignment.subjectColor);
+            const lightRgb = lightenRGB(rgb);
+            cellData.cell.styles.fillColor = lightRgb as [number, number, number];
+          }
+        }
+      },
+    });
+  });
+
+  doc.save(`Master_Timetable_${new Date().toISOString().split('T')[0]}.pdf`);
+}


### PR DESCRIPTION
- Added new timetables and periods tables to the schema, including fields for timetable details, period information, and their respective statuses.
- Introduced timetableAssignments table to link timetables with periods, teachers, and subjects, enhancing scheduling capabilities.
- Updated API definitions to include the new timetable and period modules, improving access to timetable management functionalities.
- Modified the AppSidebar to include a navigation item for Timetable, enhancing admin access to timetable management features.