### PR TITLE
feat: add monthly enrollment target to platform settings and dashboard

### DIFF
--- a/convex/platformSettings.ts
+++ b/convex/platformSettings.ts
@@ -16,12 +16,16 @@ export const get = query({
         supportEmail: 'support@schoolflow.com',
         maxSchools: 1000,
         defaultPricePerStudent: 10,
+        monthlyEnrollmentTarget: undefined,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       };
     }
-    
-    return settings;
+
+    return {
+      ...settings,
+      monthlyEnrollmentTarget: settings.monthlyEnrollmentTarget,
+    };
   },
 });
 
@@ -32,32 +36,30 @@ export const update = mutation({
     supportEmail: v.string(),
     maxSchools: v.number(),
     defaultPricePerStudent: v.number(),
+    monthlyEnrollmentTarget: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const existing = await ctx.db
       .query('platformSettings')
       .order('desc')
       .first();
-    
+
+    const updates = {
+      platformName: args.platformName,
+      supportEmail: args.supportEmail,
+      maxSchools: args.maxSchools,
+      defaultPricePerStudent: args.defaultPricePerStudent,
+      monthlyEnrollmentTarget: args.monthlyEnrollmentTarget,
+      updatedAt: new Date().toISOString(),
+    };
+
     if (existing) {
-      // Update existing settings
-      await ctx.db.patch(existing._id, {
-        platformName: args.platformName,
-        supportEmail: args.supportEmail,
-        maxSchools: args.maxSchools,
-        defaultPricePerStudent: args.defaultPricePerStudent,
-        updatedAt: new Date().toISOString(),
-      });
+      await ctx.db.patch(existing._id, updates);
       return existing._id;
     } else {
-      // Create new settings
       return await ctx.db.insert('platformSettings', {
-        platformName: args.platformName,
-        supportEmail: args.supportEmail,
-        maxSchools: args.maxSchools,
-        defaultPricePerStudent: args.defaultPricePerStudent,
+        ...updates,
         createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
       });
     }
   },

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -153,6 +153,7 @@ export default defineSchema({
     supportEmail: v.string(),
     maxSchools: v.number(),
     defaultPricePerStudent: v.number(),
+    monthlyEnrollmentTarget: v.optional(v.number()),
     createdAt: v.string(),
     updatedAt: v.string(),
   }),

--- a/convex/schools.ts
+++ b/convex/schools.ts
@@ -263,17 +263,106 @@ export const getDashboardStats = query({
     const admins = await ctx.db.query('schoolAdmins').collect();
     const subscriptions = await ctx.db.query('subscriptions').collect();
 
+    const activeSchoolsList = schools.filter((s) => s.status === 'active');
+    const totalStudents = activeSchoolsList.reduce((sum, s) => sum + s.studentCount, 0);
+    const now = new Date();
+    const currentYear = now.getFullYear();
+    const currentMonth = now.getMonth() + 1;
+    const monthlyRevenue = subscriptions
+      .filter((s) => s.status === 'verified')
+      .reduce((sum, s) => {
+        const dateStr = s.verifiedDate ?? s.paymentDate;
+        if (!dateStr) return sum;
+        const d = new Date(dateStr);
+        if (d.getFullYear() === currentYear && d.getMonth() + 1 === currentMonth) return sum + (s.totalAmount ?? 0);
+        return sum;
+      }, 0);
+
     return {
       totalSchools: schools.length,
-      activeSchools: schools.filter((s) => s.status === 'active').length,
+      activeSchools: activeSchoolsList.length,
       pendingApproval: schools.filter((s) => s.status === 'pending_approval').length,
-      totalStudents: 0, // No students enrolled yet - studentCount is subscription capacity, not actual enrollments
+      totalStudents,
       totalRevenue: subscriptions.reduce((sum, s) => sum + (s.status === 'verified' ? s.totalAmount : 0), 0),
-      monthlyRevenue: subscriptions
-        .filter((s) => s.status === 'verified')
-        .reduce((sum, s) => sum + s.totalAmount, 0),
+      monthlyRevenue,
       activeAdmins: admins.filter((a) => a.status === 'active').length,
       pendingPayments: subscriptions.filter((s) => s.status === 'pending').length,
+    };
+  },
+});
+
+/** Last 12 months in YYYY-MM format, most recent first */
+function last12MonthKeys(): string[] {
+  const keys: string[] = [];
+  const now = new Date();
+  for (let i = 0; i < 12; i++) {
+    const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+    keys.push(`${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`);
+  }
+  return keys.reverse();
+}
+
+/** Format YYYY-MM as short label e.g. "Jan 25" */
+function monthLabel(ym: string): string {
+  const [y, m] = ym.split('-').map(Number);
+  const date = new Date(y, m - 1, 1);
+  return date.toLocaleDateString('en-US', { month: 'short', year: '2-digit' });
+}
+
+export const getDashboardChartData = query({
+  args: {},
+  handler: async (ctx) => {
+    const schools = await ctx.db.query('schools').collect();
+    const subscriptions = await ctx.db.query('subscriptions').collect();
+    const months = last12MonthKeys();
+
+    const revenueByMonth = months.map((monthKey) => {
+      const [year, month] = monthKey.split('-').map(Number);
+      const revenue = subscriptions
+        .filter((s) => s.status === 'verified')
+        .reduce((sum, s) => {
+          const dateStr = s.verifiedDate ?? s.paymentDate;
+          if (!dateStr) return sum;
+          const d = new Date(dateStr);
+          if (d.getFullYear() === year && d.getMonth() + 1 === month) return sum + (s.totalAmount ?? 0);
+          return sum;
+        }, 0);
+      return { month: monthLabel(monthKey), monthKey, revenue };
+    });
+
+    const schoolGrowthByMonth = months.map((monthKey) => {
+      const [year, month] = monthKey.split('-').map(Number);
+      const newSchools = schools.filter((s) => {
+        const d = new Date(s.registrationDate);
+        return d.getFullYear() === year && d.getMonth() + 1 === month;
+      });
+      const active = newSchools.filter((s) => s.status === 'active').length;
+      const pending = newSchools.filter((s) => s.status === 'pending_approval' || s.status === 'pending_payment').length;
+      return {
+        month: monthLabel(monthKey),
+        monthKey,
+        active,
+        pending,
+        newSchools: newSchools.length,
+      };
+    });
+
+    const platformSettings = await ctx.db.query('platformSettings').order('desc').first();
+    const enrollmentTarget = platformSettings?.monthlyEnrollmentTarget ?? 0;
+
+    const enrollmentByMonth = months.map((monthKey) => {
+      const [year, month] = monthKey.split('-').map(Number);
+      const endOfMonth = new Date(year, month, 0);
+      const enrolled = schools
+        .filter((s) => s.status === 'active' && new Date(s.registrationDate) <= endOfMonth)
+        .reduce((sum, s) => sum + s.studentCount, 0);
+      return { month: monthLabel(monthKey), monthKey, enrolled, target: enrollmentTarget };
+    });
+
+    return {
+      revenueByMonth,
+      schoolGrowthByMonth,
+      enrollmentByMonth,
     };
   },
 });

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -38,37 +38,37 @@
 }
 
 .dark {
-  --background: hsl(0 0% 3.9%);
+  --background: hsl(0 0% 0%);
   --foreground: hsl(0 0% 98%);
-  --card: hsl(0 0% 3.9%);
+  --card: hsl(0 0% 0%);
   --card-foreground: hsl(0 0% 98%);
-  --popover: hsl(0 0% 3.9%);
+  --popover: hsl(0 0% 0%);
   --popover-foreground: hsl(0 0% 98%);
   --primary: hsl(0 0% 98%);
   --primary-foreground: hsl(0 0% 9%);
-  --secondary: hsl(0 0% 14.9%);
+  --secondary: hsl(0 0% 6%);
   --secondary-foreground: hsl(0 0% 98%);
-  --muted: hsl(0 0% 14.9%);
+  --muted: hsl(0 0% 6%);
   --muted-foreground: hsl(0 0% 63.9%);
-  --accent: hsl(0 0% 14.9%);
+  --accent: hsl(0 0% 6%);
   --accent-foreground: hsl(0 0% 98%);
   --destructive: hsl(0 62.8% 30.6%);
   --destructive-foreground: hsl(0 0% 98%);
-  --border: hsl(0 0% 14.9%);
-  --input: hsl(0 0% 14.9%);
+  --border: hsl(0 0% 12%);
+  --input: hsl(0 0% 12%);
   --ring: hsl(0 0% 83.1%);
   --chart-1: hsl(220 70% 50%);
   --chart-2: hsl(160 60% 45%);
   --chart-3: hsl(30 80% 55%);
   --chart-4: hsl(280 65% 60%);
   --chart-5: hsl(340 75% 55%);
-  --sidebar-background: hsl(240 5.9% 10%);
-  --sidebar-foreground: hsl(240 4.8% 95.9%);
+  --sidebar-background: hsl(0 0% 0%);
+  --sidebar-foreground: hsl(0 0% 98%);
   --sidebar-primary: hsl(224.3 76.3% 48%);
   --sidebar-primary-foreground: hsl(0 0% 100%);
-  --sidebar-accent: hsl(240 3.7% 15.9%);
-  --sidebar-accent-foreground: hsl(240 4.8% 95.9%);
-  --sidebar-border: hsl(240 3.7% 15.9%);
+  --sidebar-accent: hsl(0 0% 8%);
+  --sidebar-accent-foreground: hsl(0 0% 98%);
+  --sidebar-border: hsl(0 0% 12%);
   --sidebar-ring: hsl(217.2 91.2% 59.8%);
 }
 

--- a/src/app/super-admin/approvals/page.tsx
+++ b/src/app/super-admin/approvals/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import * as React from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
 import { useQuery, useMutation } from 'convex/react';
 import { api } from '../../../../convex/_generated/api';
 import type { Id } from '../../../../convex/_generated/dataModel';
@@ -85,6 +86,15 @@ interface SchoolCreationRequest {
 }
 
 export default function ApprovalsPage(): React.JSX.Element {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const tabParam = searchParams.get('tab');
+  const activeTab = tabParam === 'schools' ? 'schools' : 'payments';
+
+  const setActiveTab = (value: string) => {
+    router.push(`/super-admin/approvals?tab=${value}`);
+  };
+
   const pendingPayments = useQuery(api.paymentProofs.getPending) as PaymentProof[] | undefined;
   const pendingSchools = useQuery(api.schoolCreationRequests.getPending) as SchoolCreationRequest[] | undefined;
 
@@ -99,6 +109,9 @@ export default function ApprovalsPage(): React.JSX.Element {
   const [rejectReason, setRejectReason] = React.useState<string>('');
   const [rejectType, setRejectType] = React.useState<'payment' | 'school' | null>(null);
   const [isProcessing, setIsProcessing] = React.useState<boolean>(false);
+
+  const pendingPaymentCount = pendingPayments?.length ?? 0;
+  const pendingSchoolCount = pendingSchools?.length ?? 0;
 
   const handleApprovePayment = async (payment: PaymentProof): Promise<void> => {
     setIsProcessing(true);
@@ -209,7 +222,30 @@ export default function ApprovalsPage(): React.JSX.Element {
         </p>
       </div>
 
-      <Tabs defaultValue="payments" className="space-y-4">
+      <div className="grid gap-4 sm:grid-cols-2">
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Pending payments</CardTitle>
+            <FileText className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{pendingPaymentCount}</div>
+            <p className="text-xs text-muted-foreground">Payment proofs awaiting verification</p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+            <CardTitle className="text-sm font-medium">Pending schools</CardTitle>
+            <School className="h-4 w-4 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{pendingSchoolCount}</div>
+            <p className="text-xs text-muted-foreground">School creation requests awaiting approval</p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
         <TabsList>
           <TabsTrigger value="payments">
             <FileText className="mr-2 h-4 w-4" />

--- a/src/app/super-admin/page.tsx
+++ b/src/app/super-admin/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import {  useMemo } from 'react';
+import { useMemo } from 'react';
+import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { StatsCard } from '@/components/dashboard/stats-card';
 import { School, Users, DollarSign, AlertCircle, TrendingUp, GraduationCap, BarChart as BarChartIcon } from 'lucide-react';
@@ -29,16 +30,31 @@ const COLORS = ['#3b82f6', '#10b981', '#f59e0b', '#ef4444'];
 
 export default function SuperAdminDashboardPage(): React.JSX.Element {
   const stats = useQuery(api.schools.getDashboardStats);
+  const chartData = useQuery(api.schools.getDashboardChartData);
   const auditLogs = useQuery(api.auditLogs.list);
   const schools = useQuery(api.schools.list);
 
-  // Revenue trend data (empty - no data in system yet)
-  const revenueData: Array<{ month: string; revenue: number; students: number }> = [];
+  const revenueData = useMemo(() => {
+    if (!chartData?.revenueByMonth) return [];
+    const enrollmentByKey = new Map(
+      (chartData.enrollmentByMonth ?? []).map((e) => [e.monthKey, e.enrolled])
+    );
+    return chartData.revenueByMonth.map((r) => ({
+      month: r.month,
+      revenue: r.revenue,
+      students: enrollmentByKey.get(r.monthKey) ?? 0,
+    }));
+  }, [chartData]);
 
-  // School growth data (empty - no data in system yet)
-  const schoolGrowthData: Array<{ month: string; active: number; pending: number }> = [];
+  const schoolGrowthData = useMemo(() => {
+    if (!chartData?.schoolGrowthByMonth) return [];
+    return chartData.schoolGrowthByMonth.map((g) => ({
+      month: g.month,
+      active: g.active,
+      pending: g.pending,
+    }));
+  }, [chartData]);
 
-  // Status distribution data (real data from schools)
   const statusData = useMemo(() => {
     if (!schools) return [];
     const statusCounts = schools.reduce((acc: Record<string, number>, school) => {
@@ -52,8 +68,19 @@ export default function SuperAdminDashboardPage(): React.JSX.Element {
     }));
   }, [schools]);
 
-  // Monthly student enrollment data (empty - no data in system yet)
-  const enrollmentData: Array<{ month: string; enrolled: number; target: number }> = [];
+  const enrollmentData = useMemo(() => {
+    if (!chartData?.enrollmentByMonth) return [];
+    return chartData.enrollmentByMonth.map((e) => ({
+      month: e.month,
+      enrolled: e.enrolled,
+      target: e.target,
+    }));
+  }, [chartData]);
+
+  const hasRevenueData = revenueData.some((d) => d.revenue > 0 || d.students > 0);
+  const hasSchoolGrowthData = schoolGrowthData.some((d) => d.active > 0 || d.pending > 0);
+  const hasEnrollmentData = enrollmentData.some((d) => d.enrolled > 0);
+  const showEnrollmentTarget = enrollmentData.some((d) => d.target > 0);
 
   if (!stats) {
     return (
@@ -141,7 +168,7 @@ export default function SuperAdminDashboardPage(): React.JSX.Element {
             <CardTitle>Revenue & Student Growth</CardTitle>
           </CardHeader>
           <CardContent>
-            {revenueData.length === 0 ? (
+            {!hasRevenueData ? (
               <div className="flex flex-col items-center justify-center h-75 space-y-4">
                 <div className="relative">
                   <div className="absolute inset-0 bg-linear-to-br from-green-100 to-blue-100 dark:from-green-900/20 dark:to-blue-900/20 rounded-full blur-xl animate-pulse" />
@@ -202,7 +229,7 @@ export default function SuperAdminDashboardPage(): React.JSX.Element {
             <CardTitle>School Growth Trend</CardTitle>
           </CardHeader>
           <CardContent>
-            {schoolGrowthData.length === 0 ? (
+            {!hasSchoolGrowthData ? (
               <div className="flex flex-col items-center justify-center h-75 space-y-4">
                 <div className="relative">
                   <div className="absolute inset-0 bg-linear-to-br from-blue-100 to-purple-100 dark:from-blue-900/20 dark:to-purple-900/20 rounded-full blur-xl animate-pulse" />
@@ -266,7 +293,7 @@ export default function SuperAdminDashboardPage(): React.JSX.Element {
             <CardTitle>Monthly Student Enrollment</CardTitle>
           </CardHeader>
           <CardContent>
-            {enrollmentData.length === 0 ? (
+            {!hasEnrollmentData ? (
               <div className="flex flex-col items-center justify-center h-75 space-y-4">
                 <div className="relative">
                   <div className="absolute inset-0 bg-linear-to-br from-purple-100 to-pink-100 dark:from-purple-900/20 dark:to-pink-900/20 rounded-full blur-xl animate-pulse" />
@@ -298,15 +325,17 @@ export default function SuperAdminDashboardPage(): React.JSX.Element {
                     name="Enrolled"
                     dot={{ r: 4 }}
                   />
-                  <Line
-                    type="monotone"
-                    dataKey="target"
-                    stroke="#ef4444"
-                    strokeWidth={2}
-                    strokeDasharray="5 5"
-                    name="Target"
-                    dot={{ r: 4 }}
-                  />
+                  {showEnrollmentTarget && (
+                    <Line
+                      type="monotone"
+                      dataKey="target"
+                      stroke="#ef4444"
+                      strokeWidth={2}
+                      strokeDasharray="5 5"
+                      name="Target"
+                      dot={{ r: 4 }}
+                    />
+                  )}
                 </LineChart>
               </ResponsiveContainer>
             )}
@@ -348,7 +377,10 @@ export default function SuperAdminDashboardPage(): React.JSX.Element {
           <CardContent>
             <div className="space-y-4">
               {stats.pendingPayments > 0 && (
-                <div className="flex items-center justify-between p-3 bg-yellow-50 dark:bg-yellow-950 rounded-lg">
+                <Link
+                  href="/super-admin/approvals?tab=payments"
+                  className="flex items-center justify-between p-3 bg-yellow-50 dark:bg-yellow-950 rounded-lg hover:bg-yellow-100 dark:hover:bg-yellow-900/40 transition-colors"
+                >
                   <div>
                     <p className="text-sm font-medium text-yellow-900 dark:text-yellow-200">
                       Payment Verification
@@ -357,19 +389,22 @@ export default function SuperAdminDashboardPage(): React.JSX.Element {
                       {stats.pendingPayments} payment(s) awaiting verification
                     </p>
                   </div>
-                  <AlertCircle className="h-5 w-5 text-yellow-600 dark:text-yellow-400" />
-                </div>
+                  <AlertCircle className="h-5 w-5 text-yellow-600 dark:text-yellow-400 shrink-0" />
+                </Link>
               )}
               {stats.pendingApproval > 0 && (
-                <div className="flex items-center justify-between p-3 bg-blue-50 dark:bg-blue-950 rounded-lg">
+                <Link
+                  href="/super-admin/approvals?tab=schools"
+                  className="flex items-center justify-between p-3 bg-blue-50 dark:bg-blue-950 rounded-lg hover:bg-blue-100 dark:hover:bg-blue-900/40 transition-colors"
+                >
                   <div>
                     <p className="text-sm font-medium text-blue-900 dark:text-blue-200">School Approval</p>
                     <p className="text-xs text-blue-700 dark:text-blue-300">
                       {stats.pendingApproval} school(s) awaiting approval
                     </p>
                   </div>
-                  <School className="h-5 w-5 text-blue-600 dark:text-blue-400" />
-                </div>
+                  <School className="h-5 w-5 text-blue-600 dark:text-blue-400 shrink-0" />
+                </Link>
               )}
               {stats.pendingPayments === 0 && stats.pendingApproval === 0 && (
                 <p className="text-sm text-gray-500 dark:text-gray-400">No pending actions</p>

--- a/src/app/super-admin/profile/page.tsx
+++ b/src/app/super-admin/profile/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, JSX } from "react";
+import { useState, useEffect } from "react";
 import {
   Card,
   CardContent,
@@ -13,11 +13,30 @@ import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useAuth } from "@/hooks/useAuth";
-import { useMutation } from "convex/react";
-import { toast } from "sonner";
-import { Eye, EyeOff } from "lucide-react";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
+import { toast } from "sonner";
+import { Eye, EyeOff, Loader2 } from "lucide-react";
+import axios from "axios";
+
+function validateNewPassword(password: string): { valid: boolean; message: string } {
+  if (password.length < 8) {
+    return { valid: false, message: "Password must be at least 8 characters long" };
+  }
+  if (!/[A-Z]/.test(password)) {
+    return { valid: false, message: "Password must contain at least one uppercase letter" };
+  }
+  if (!/[a-z]/.test(password)) {
+    return { valid: false, message: "Password must contain at least one lowercase letter" };
+  }
+  if (!/[0-9]/.test(password)) {
+    return { valid: false, message: "Password must contain at least one number" };
+  }
+  if (!/[!@#$%^&*]/.test(password)) {
+    return { valid: false, message: "Password must contain at least one special character (!@#$%^&*)" };
+  }
+  return { valid: true, message: "" };
+}
 
 export default function ProfilePage(): React.JSX.Element {
   const { user } = useAuth();
@@ -32,10 +51,10 @@ export default function ProfilePage(): React.JSX.Element {
     new: false,
     confirm: false,
   });
+  const [isChangingPassword, setIsChangingPassword] = useState(false);
 
   const activityLogs = useQuery(api.auditLogs.list);
   const updateProfile = useMutation(api.auth.updateProfile);
-  const changePassword = useMutation(api.auth.changePassword);
 
   useEffect(() => {
     if (user && profileData.name === "" && profileData.email === "") {
@@ -59,20 +78,35 @@ export default function ProfilePage(): React.JSX.Element {
       toast.error("New passwords do not match");
       return;
     }
+    const validation = validateNewPassword(passwordData.newPassword);
+    if (!validation.valid) {
+      toast.error(validation.message);
+      return;
+    }
+    setIsChangingPassword(true);
     try {
-      await changePassword({
-        email: user?.email || "",
-        oldPassword: passwordData.currentPassword,
-        newPassword: passwordData.newPassword,
-      });
+      await axios.post(
+        "/api/auth/change-password",
+        {
+          currentPassword: passwordData.currentPassword,
+          newPassword: passwordData.newPassword,
+        },
+        { withCredentials: true }
+      );
       toast.success("Password changed successfully");
       setPasswordData({
         currentPassword: "",
         newPassword: "",
         confirmPassword: "",
       });
-    } catch (error) {
-      toast.error("Failed to change password");
+    } catch (err) {
+      const message =
+        axios.isAxiosError(err) && err.response?.data?.error
+          ? String(err.response.data.error)
+          : "Failed to change password";
+      toast.error(message);
+    } finally {
+      setIsChangingPassword(false);
     }
   };
 
@@ -248,7 +282,16 @@ export default function ProfilePage(): React.JSX.Element {
                     </button>
                   </div>
                 </div>
-                <Button type="submit">Change Password</Button>
+                <Button type="submit" disabled={isChangingPassword}>
+                      {isChangingPassword ? (
+                        <>
+                          <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                          Changing...
+                        </>
+                      ) : (
+                        "Change Password"
+                      )}
+                    </Button>
               </form>
             </CardContent>
           </Card>

--- a/src/app/super-admin/settings/page.tsx
+++ b/src/app/super-admin/settings/page.tsx
@@ -40,6 +40,7 @@ export default function SettingsPage(): React.JSX.Element {
     supportEmail: 'support@schoolflow.com',
     maxSchools: '1000',
     defaultPricePerStudent: '10',
+    monthlyEnrollmentTarget: '',
   });
 
   const [notifications, setNotifications] = useState({
@@ -63,6 +64,10 @@ export default function SettingsPage(): React.JSX.Element {
         supportEmail: platformSettingsData.supportEmail,
         maxSchools: String(platformSettingsData.maxSchools),
         defaultPricePerStudent: String(platformSettingsData.defaultPricePerStudent),
+        monthlyEnrollmentTarget:
+          platformSettingsData.monthlyEnrollmentTarget != null
+            ? String(platformSettingsData.monthlyEnrollmentTarget)
+            : '',
       });
     }
   }, [platformSettingsData]);
@@ -98,6 +103,9 @@ export default function SettingsPage(): React.JSX.Element {
         supportEmail: platformSettings.supportEmail,
         maxSchools: parseInt(platformSettings.maxSchools, 10),
         defaultPricePerStudent: parseInt(platformSettings.defaultPricePerStudent, 10),
+        monthlyEnrollmentTarget: platformSettings.monthlyEnrollmentTarget
+          ? parseInt(platformSettings.monthlyEnrollmentTarget, 10)
+          : undefined,
       });
       toast.success('Platform settings updated successfully');
     } catch (error) {
@@ -234,6 +242,22 @@ export default function SettingsPage(): React.JSX.Element {
                       setPlatformSettings({ ...platformSettings, defaultPricePerStudent: e.target.value })
                     }
                   />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="monthlyEnrollmentTarget">Monthly Enrollment Target</Label>
+                  <Input
+                    id="monthlyEnrollmentTarget"
+                    type="number"
+                    min={0}
+                    placeholder="Optional — used as target line on dashboard"
+                    value={platformSettings.monthlyEnrollmentTarget}
+                    onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                      setPlatformSettings({ ...platformSettings, monthlyEnrollmentTarget: e.target.value })
+                    }
+                  />
+                  <p className="text-xs text-muted-foreground">
+                    Target student capacity shown on the dashboard enrollment chart. Leave empty to hide.
+                  </p>
                 </div>
                 <Button type="submit" disabled={isSavingPlatform}>
                   {isSavingPlatform ? 'Saving...' : 'Save Platform Settings'}

--- a/src/components/dashboard/app-sidebar.tsx
+++ b/src/components/dashboard/app-sidebar.tsx
@@ -19,8 +19,15 @@ import {
   Clock,
   Shield,
   Activity,
+  ChevronDown,
+  UserCircle,
 } from 'lucide-react';
 
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
 import {
   Sidebar,
   SidebarContent,
@@ -31,24 +38,69 @@ import {
   SidebarGroup,
   SidebarGroupContent,
   SidebarGroupLabel,
+  SidebarMenuSub,
+  SidebarMenuSubItem,
+  SidebarMenuSubButton,
 } from '@/components/ui/sidebar';
 
-const navItems = [
+const standaloneNavItems = [
   { href: '/super-admin', icon: LayoutDashboard, label: 'Dashboard' },
   { href: '/super-admin/approvals', icon: CheckSquare, label: 'Approvals' },
-  { href: '/super-admin/profile', icon: User, label: 'Profile Management' },
-  { href: '/super-admin/manage-admins', icon: Shield, label: 'Manage Admins' },
-  { href: '/super-admin/school-admins', icon: Users, label: 'School Admins' },
-  { href: '/super-admin/schools', icon: School, label: 'Schools' },
-  { href: '/super-admin/subscriptions', icon: CreditCard, label: 'Subscriptions' },
-  { href: '/super-admin/trial-management', icon: Clock, label: 'Trial Management' },
-  { href: '/super-admin/activity', icon: Activity, label: 'Activity & Sessions' },
-  { href: '/super-admin/audit-logs', icon: FileText, label: 'Audit Logs' },
-  { href: '/super-admin/notifications', icon: Bell, label: 'Notifications' },
-  { href: '/super-admin/reports', icon: BarChart3, label: 'Reports' },
-  { href: '/super-admin/settings', icon: Settings, label: 'Settings' },
-  { href: '/super-admin/support', icon: HelpCircle, label: 'Support' },
 ];
+
+const navGroups: Array<{
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  items: Array<{ href: string; icon: React.ComponentType<{ className?: string }>; label: string }>;
+}> = [
+  {
+    label: 'Users & access',
+    icon: Users,
+    items: [
+      { href: '/super-admin/profile', icon: User, label: 'Profile Management' },
+      { href: '/super-admin/manage-admins', icon: Shield, label: 'Manage Admins' },
+      { href: '/super-admin/school-admins', icon: Users, label: 'School Admins' },
+    ],
+  },
+  {
+    label: 'Schools & billing',
+    icon: School,
+    items: [
+      { href: '/super-admin/schools', icon: School, label: 'Schools' },
+      { href: '/super-admin/subscriptions', icon: CreditCard, label: 'Subscriptions' },
+      { href: '/super-admin/trial-management', icon: Clock, label: 'Trial Management' },
+    ],
+  },
+  {
+    label: 'Activity & security',
+    icon: Activity,
+    items: [
+      { href: '/super-admin/activity', icon: Activity, label: 'Activity & Sessions' },
+      { href: '/super-admin/audit-logs', icon: FileText, label: 'Audit Logs' },
+    ],
+  },
+  {
+    label: 'Reports & notifications',
+    icon: Bell,
+    items: [
+      { href: '/super-admin/notifications', icon: Bell, label: 'Notifications' },
+      { href: '/super-admin/reports', icon: BarChart3, label: 'Reports' },
+    ],
+  },
+  {
+    label: 'System',
+    icon: Settings,
+    items: [
+      { href: '/super-admin/account', icon: UserCircle, label: 'Account' },
+      { href: '/super-admin/settings', icon: Settings, label: 'Settings' },
+      { href: '/super-admin/support', icon: HelpCircle, label: 'Support' },
+    ],
+  },
+];
+
+function isPathInGroup(pathname: string, items: Array<{ href: string }>): boolean {
+  return items.some((item) => pathname === item.href || pathname.startsWith(item.href + '/'));
+}
 
 export function AppSidebar(): React.JSX.Element {
   const pathname = usePathname();
@@ -77,7 +129,7 @@ export function AppSidebar(): React.JSX.Element {
           <SidebarGroupLabel>Platform</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {navItems.map((item) => {
+              {standaloneNavItems.map((item) => {
                 const Icon = item.icon;
                 const isActive = pathname === item.href;
                 return (
@@ -89,6 +141,45 @@ export function AppSidebar(): React.JSX.Element {
                       </Link>
                     </SidebarMenuButton>
                   </SidebarMenuItem>
+                );
+              })}
+              {navGroups.map((group) => {
+                const GroupIcon = group.icon;
+                const hasActiveChild = isPathInGroup(pathname, group.items);
+                return (
+                  <Collapsible
+                    key={group.label}
+                    defaultOpen={hasActiveChild}
+                    className="group/collapsible"
+                  >
+                    <SidebarMenuItem>
+                      <CollapsibleTrigger asChild>
+                        <SidebarMenuButton tooltip={group.label}>
+                          <GroupIcon />
+                          <span>{group.label}</span>
+                          <ChevronDown className="ml-auto size-4 transition-transform group-data-[state=open]/collapsible:rotate-180" />
+                        </SidebarMenuButton>
+                      </CollapsibleTrigger>
+                      <CollapsibleContent>
+                        <SidebarMenuSub>
+                          {group.items.map((item) => {
+                            const SubIcon = item.icon;
+                            const isActive = pathname === item.href;
+                            return (
+                              <SidebarMenuSubItem key={item.href}>
+                                <SidebarMenuSubButton asChild isActive={isActive}>
+                                  <Link href={item.href}>
+                                    <SubIcon />
+                                    <span>{item.label}</span>
+                                  </Link>
+                                </SidebarMenuSubButton>
+                              </SidebarMenuSubItem>
+                            );
+                          })}
+                        </SidebarMenuSub>
+                      </CollapsibleContent>
+                    </SidebarMenuItem>
+                  </Collapsible>
                 );
               })}
             </SidebarMenu>

--- a/src/components/dashboard/desktop-header.tsx
+++ b/src/components/dashboard/desktop-header.tsx
@@ -41,10 +41,15 @@ import { SidebarTrigger } from '@/components/ui/sidebar';
 
 const searchItems = [
   { label: 'Dashboard', href: '/super-admin', keywords: ['home', 'overview', 'metrics'] },
-  { label: 'Profile Management', href: '/super-admin/profile', keywords: ['profile', 'account', 'settings'] },
-  { label: 'School Admins', href: '/super-admin/school-admins', keywords: ['admins', 'users', 'invite'] },
+  { label: 'Approvals', href: '/super-admin/approvals', keywords: ['approvals', 'payments', 'schools'] },
+  { label: 'Profile Management', href: '/super-admin/profile', keywords: ['profile', 'password', 'settings'] },
+  { label: 'Account', href: '/super-admin/account', keywords: ['account', 'theme', 'logout'] },
+  { label: 'Manage Admins', href: '/super-admin/manage-admins', keywords: ['admins', 'super', 'manage'] },
+  { label: 'School Admins', href: '/super-admin/school-admins', keywords: ['school admins', 'users', 'invite'] },
   { label: 'Schools', href: '/super-admin/schools', keywords: ['schools', 'institutions', 'approve'] },
   { label: 'Subscriptions', href: '/super-admin/subscriptions', keywords: ['billing', 'payments', 'subscription'] },
+  { label: 'Trial Management', href: '/super-admin/trial-management', keywords: ['trial', 'trials'] },
+  { label: 'Activity & Sessions', href: '/super-admin/activity', keywords: ['activity', 'sessions', 'login'] },
   { label: 'Audit Logs', href: '/super-admin/audit-logs', keywords: ['logs', 'history', 'audit'] },
   { label: 'Notifications', href: '/super-admin/notifications', keywords: ['notifications', 'alerts', 'messages'] },
   { label: 'Reports & Analytics', href: '/super-admin/reports', keywords: ['reports', 'analytics', 'charts'] },

--- a/src/components/school-admin/app-sidebar.tsx
+++ b/src/components/school-admin/app-sidebar.tsx
@@ -1,17 +1,8 @@
 'use client';
 
-import {
-  Sidebar,
-  SidebarContent,
-  SidebarFooter,
-  SidebarGroup,
-  SidebarGroupContent,
-  SidebarGroupLabel,
-  SidebarHeader,
-  SidebarMenu,
-  SidebarMenuButton,
-  SidebarMenuItem,
-} from '@/components/ui/sidebar';
+import * as React from 'react';
+import Link from 'next/link';
+import { usePathname, useRouter } from 'next/navigation';
 import {
   LayoutDashboard,
   School,
@@ -31,9 +22,30 @@ import {
   ClipboardCheck,
   Megaphone,
   BarChart3,
+  ChevronDown,
 } from 'lucide-react';
-import Link from 'next/link';
-import { usePathname, useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubItem,
+  SidebarMenuSubButton,
+} from '@/components/ui/sidebar';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -44,107 +56,88 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/components/ui/alert-dialog';
-import { JSX, useState } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { toast } from 'sonner';
 
-const menuItems = [
+const standaloneNavItems = [
+  { title: 'Dashboard', icon: LayoutDashboard, url: '/school-admin' },
+];
+
+const navGroups: Array<{
+  label: string;
+  icon: React.ComponentType<{ className?: string }>;
+  items: Array<{ title: string; icon: React.ComponentType<{ className?: string }>; url: string }>;
+}> = [
   {
-    title: 'Dashboard',
-    icon: LayoutDashboard,
-    url: '/school-admin',
-  },
-  {
-    title: 'My School',
+    label: 'School & setup',
     icon: School,
-    url: '/school-admin/school',
+    items: [
+      { title: 'My School', icon: School, url: '/school-admin/school' },
+      { title: 'Academic Years', icon: Calendar, url: '/school-admin/academic-years' },
+    ],
   },
   {
-    title: 'Academic Years',
-    icon: Calendar,
-    url: '/school-admin/academic-years',
-  },
-  {
-    title: 'Teachers',
+    label: 'People & classes',
     icon: Users,
-    url: '/school-admin/teachers',
+    items: [
+      { title: 'Teachers', icon: Users, url: '/school-admin/teachers' },
+      { title: 'Classes', icon: BookOpen, url: '/school-admin/classes' },
+      { title: 'Students', icon: GraduationCap, url: '/school-admin/students' },
+      { title: 'Subjects', icon: BookOpen, url: '/school-admin/subjects' },
+    ],
   },
   {
-    title: 'Classes',
-    icon: BookOpen,
-    url: '/school-admin/classes',
-  },
-  {
-    title: 'Students',
-    icon: GraduationCap,
-    url: '/school-admin/students',
-  },
-  {
-    title: 'Subjects',
-    icon: BookOpen,
-    url: '/school-admin/subjects',
-  },
-  {
-    title: 'Timetable',
+    label: 'Timetable & attendance',
     icon: Clock,
-    url: '/school-admin/timetable',
+    items: [
+      { title: 'Timetable', icon: Clock, url: '/school-admin/timetable' },
+      { title: 'Attendance', icon: ClipboardCheck, url: '/school-admin/attendance' },
+    ],
   },
-   {
-    title: 'Attendance',
-    icon: ClipboardCheck,
-    url: '/school-admin/attendance',
-  },
-   {
-    title: 'Fees',
-    icon: DollarSign,
-    url: '/school-admin/fees',
-  },
-   {
-    title: 'Events',
-    icon: Calendar,
-    url: '/school-admin/events',
-  },
-   {
-    title: 'Exams',
+  {
+    label: 'Exams & reports',
     icon: FileText,
-    url: '/school-admin/exams',
+    items: [
+      { title: 'Exams', icon: FileText, url: '/school-admin/exams' },
+      { title: 'Reports', icon: BarChart3, url: '/school-admin/reports' },
+    ],
   },
   {
-    title: 'Reports',
-    icon: BarChart3,
-    url: '/school-admin/reports',
+    label: 'Finance',
+    icon: DollarSign,
+    items: [
+      { title: 'Fees', icon: DollarSign, url: '/school-admin/fees' },
+      { title: 'Subscription', icon: CreditCard, url: '/school-admin/subscription' },
+    ],
   },
   {
-    title: 'Announcements',
+    label: 'Events & communication',
     icon: Megaphone,
-    url: '/school-admin/announcements',
+    items: [
+      { title: 'Events', icon: Calendar, url: '/school-admin/events' },
+      { title: 'Announcements', icon: Megaphone, url: '/school-admin/announcements' },
+      { title: 'Notifications', icon: Bell, url: '/school-admin/notifications' },
+    ],
   },
   {
-    title: 'Subscription',
-    icon: CreditCard,
-    url: '/school-admin/subscription',
-  },
-  {
-    title: 'Notifications',
-    icon: Bell,
-    url: '/school-admin/notifications',
-  },
-  {
-    title: 'Support',
-    icon: HelpCircle,
-    url: '/school-admin/support',
-  },
-  {
-    title: 'Profile',
+    label: 'Account & support',
     icon: User,
-    url: '/school-admin/profile',
-  },
-  {
-    title: 'Settings',
-    icon: Settings,
-    url: '/school-admin/settings',
+    items: [
+      { title: 'Profile', icon: User, url: '/school-admin/profile' },
+      { title: 'Settings', icon: Settings, url: '/school-admin/settings' },
+      { title: 'Support', icon: HelpCircle, url: '/school-admin/support' },
+    ],
   },
 ];
+
+function isPathInGroup(
+  pathname: string,
+  items: Array<{ url: string }>,
+): boolean {
+  return items.some(
+    (item) => pathname === item.url || pathname.startsWith(item.url + '/'),
+  );
+}
 
 export function AppSidebar(): React.JSX.Element {
   const pathname = usePathname();
@@ -162,7 +155,10 @@ export function AppSidebar(): React.JSX.Element {
     <>
       <Sidebar>
         <SidebarHeader>
-          <Link href="/" className="flex items-center gap-2 px-4 py-3 hover:opacity-80 transition-opacity">
+          <Link
+            href="/"
+            className="flex items-center gap-2 px-4 py-3 hover:opacity-80 transition-opacity"
+          >
             <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-primary">
               <GraduationCap className="h-5 w-5 text-primary-foreground" />
             </div>
@@ -177,12 +173,9 @@ export function AppSidebar(): React.JSX.Element {
             <SidebarGroupLabel>Menu</SidebarGroupLabel>
             <SidebarGroupContent>
               <SidebarMenu>
-                {menuItems.map((item) => (
-                  <SidebarMenuItem key={item.title}>
-                    <SidebarMenuButton
-                      asChild
-                      isActive={pathname === item.url}
-                    >
+                {standaloneNavItems.map((item) => (
+                  <SidebarMenuItem key={item.url}>
+                    <SidebarMenuButton asChild isActive={pathname === item.url}>
                       <Link href={item.url}>
                         <item.icon className="h-4 w-4" />
                         <span>{item.title}</span>
@@ -190,6 +183,45 @@ export function AppSidebar(): React.JSX.Element {
                     </SidebarMenuButton>
                   </SidebarMenuItem>
                 ))}
+                {navGroups.map((group) => {
+                  const GroupIcon = group.icon;
+                  const hasActiveChild = isPathInGroup(pathname, group.items);
+                  return (
+                    <Collapsible
+                      key={group.label}
+                      defaultOpen={hasActiveChild}
+                      className="group/collapsible"
+                    >
+                      <SidebarMenuItem>
+                        <CollapsibleTrigger asChild>
+                          <SidebarMenuButton>
+                            <GroupIcon className="h-4 w-4" />
+                            <span>{group.label}</span>
+                            <ChevronDown className="ml-auto size-4 transition-transform group-data-[state=open]/collapsible:rotate-180" />
+                          </SidebarMenuButton>
+                        </CollapsibleTrigger>
+                        <CollapsibleContent>
+                          <SidebarMenuSub>
+                            {group.items.map((item) => {
+                              const SubIcon = item.icon;
+                              const isActive = pathname === item.url;
+                              return (
+                                <SidebarMenuSubItem key={item.url}>
+                                  <SidebarMenuSubButton asChild isActive={isActive}>
+                                    <Link href={item.url}>
+                                      <SubIcon className="h-4 w-4" />
+                                      <span>{item.title}</span>
+                                    </Link>
+                                  </SidebarMenuSubButton>
+                                </SidebarMenuSubItem>
+                              );
+                            })}
+                          </SidebarMenuSub>
+                        </CollapsibleContent>
+                      </SidebarMenuItem>
+                    </Collapsible>
+                  );
+                })}
               </SidebarMenu>
             </SidebarGroupContent>
           </SidebarGroup>
@@ -211,12 +243,15 @@ export function AppSidebar(): React.JSX.Element {
           <AlertDialogHeader>
             <AlertDialogTitle>Confirm Logout</AlertDialogTitle>
             <AlertDialogDescription>
-              Are you sure you want to logout? You will be redirected to the home page.
+              Are you sure you want to logout? You will be redirected to the home
+              page.
             </AlertDialogDescription>
           </AlertDialogHeader>
           <AlertDialogFooter>
             <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction onClick={handleLogout}>Logout</AlertDialogAction>
+            <AlertDialogAction onClick={handleLogout}>
+              Logout
+            </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>


### PR DESCRIPTION
- Introduced a new optional field for monthly enrollment target in platform settings.
- Updated the settings retrieval and update logic to handle the new field.
- Enhanced dashboard statistics to include monthly enrollment data and target comparisons.
- Refactored dashboard chart data queries to utilize the new enrollment target for better insights.