### PR TITLE
refactor: update dialog return types and clean up imports

### DIFF
--- a/src/components/fees/delete-category-dialog.tsx
+++ b/src/components/fees/delete-category-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, JSX } from 'react';
+import { useState } from 'react';
 import { useMutation } from 'convex/react';
 import { api } from '../../../convex/_generated/api';
 import type { Id } from '../../../convex/_generated/dataModel';
@@ -29,7 +29,7 @@ export function DeleteCategoryDialog({
   open,
   onOpenChange,
   category,
-}: DeleteCategoryDialogProps): React.JSX.Element {
+}: DeleteCategoryDialogProps): React.JSX.Element | null {
   const [loading, setLoading] = useState<boolean>(false);
   const deleteCategory = useMutation(api.feeCategories.deleteFeeCategory);
 

--- a/src/components/fees/delete-fee-structure-dialog.tsx
+++ b/src/components/fees/delete-fee-structure-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, JSX } from 'react';
+import { useState } from 'react';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -31,7 +31,7 @@ export function DeleteFeeStructureDialog({
   open,
   onOpenChange,
   structure,
-}: DeleteFeeStructureDialogProps): React.JSX.Element {
+}: DeleteFeeStructureDialogProps): React.JSX.Element | null {
   const [loading, setLoading] = useState<boolean>(false);
   const deleteStructure = useMutation(api.feeStructures.deleteFeeStructure);
 

--- a/src/components/fees/edit-fee-structure-dialog.tsx
+++ b/src/components/fees/edit-fee-structure-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo, useEffect, JSX } from 'react';
+import { useState, useCallback, useMemo, useEffect } from 'react';
 import { useMutation, useQuery } from 'convex/react';
 import type { Id } from '@/../convex/_generated/dataModel';
 import { api } from '../../../convex/_generated/api';
@@ -50,7 +50,7 @@ export function EditFeeStructureDialog({
   onOpenChange,
   schoolId,
   structure,
-}: EditFeeStructureDialogProps): React.JSX.Element {
+}: EditFeeStructureDialogProps): React.JSX.Element | null {
   const [structureName, setStructureName] = useState<string>('');
   const [selectedDepartmentId, setSelectedDepartmentId] = useState<string>('none');
   const [selectedClassCode, setSelectedClassCode] = useState<string>('none');


### PR DESCRIPTION
- Removed unused JSX import from multiple dialog components for cleaner code.
- Updated return types of DeleteCategoryDialog, DeleteFeeStructureDialog, and EditFeeStructureDialog to allow for null, enhancing type safety and clarity in component rendering.