### PR TITLE
feat: add color customization for houses

### DIFF
--- a/convex/houses.ts
+++ b/convex/houses.ts
@@ -28,6 +28,7 @@ export const addHouse = mutation({
     schoolId: v.string(),
     name: v.string(),
     code: v.string(),
+    color: v.optional(v.string()),
     sortOrder: v.optional(v.number()),
     createdBy: v.string(),
   },
@@ -56,6 +57,7 @@ export const addHouse = mutation({
       schoolId: args.schoolId,
       name: args.name.trim(),
       code,
+      color: args.color && /^#[0-9A-Fa-f]{6}$/.test(args.color) ? args.color : undefined,
       sortOrder: args.sortOrder ?? existing.length,
       createdAt: now,
       updatedAt: now,
@@ -70,6 +72,7 @@ export const updateHouse = mutation({
     houseId: v.id('houses'),
     name: v.optional(v.string()),
     code: v.optional(v.string()),
+    color: v.optional(v.string()),
     sortOrder: v.optional(v.number()),
     updatedBy: v.string(),
   },
@@ -81,6 +84,9 @@ export const updateHouse = mutation({
     const updates: Record<string, unknown> = { updatedAt: now };
 
     if (args.name !== undefined) updates.name = args.name.trim();
+    if (args.color !== undefined) {
+      updates.color = args.color && /^#[0-9A-Fa-f]{6}$/.test(args.color) ? args.color : undefined;
+    }
     if (args.code !== undefined) {
       const code = args.code.trim().toUpperCase().slice(0, 6);
       if (code.length < 1) throw new Error('House code must be at least 1 character');

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -391,6 +391,7 @@ export default defineSchema({
     schoolId: v.string(),
     name: v.string(),
     code: v.string(), // e.g., "JUB", "AMB"
+    color: v.optional(v.string()), // hex e.g. "#3b82f6"
     sortOrder: v.optional(v.number()),
     createdAt: v.string(),
     updatedAt: v.string(),

--- a/src/app/school-admin/houses/page.tsx
+++ b/src/app/school-admin/houses/page.tsx
@@ -23,6 +23,7 @@ interface House {
   schoolId: string;
   name: string;
   code: string;
+  color?: string;
   sortOrder?: number;
 }
 
@@ -112,9 +113,18 @@ export default function HousesPage(): React.JSX.Element {
                   key={house._id}
                   className="flex items-center justify-between p-4 rounded-lg border hover:bg-muted/50"
                 >
-                  <div>
-                    <p className="font-medium">{house.name}</p>
-                    <p className="text-sm text-muted-foreground">Code: {house.code}</p>
+                  <div className="flex items-center gap-3">
+                    {house.color && (
+                      <span
+                        className="h-6 w-6 shrink-0 rounded-full border border-border"
+                        style={{ backgroundColor: house.color }}
+                        aria-hidden
+                      />
+                    )}
+                    <div>
+                      <p className="font-medium">{house.name}</p>
+                      <p className="text-sm text-muted-foreground">Code: {house.code}</p>
+                    </div>
                   </div>
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>

--- a/src/components/houses/add-house-dialog.tsx
+++ b/src/components/houses/add-house-dialog.tsx
@@ -17,6 +17,12 @@ import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 
+const PRESET_COLORS = [
+  '#ef4444', '#f97316', '#eab308', '#22c55e', '#14b8a6',
+  '#3b82f6', '#8b5cf6', '#ec4899', '#6366f1', '#0ea5e9',
+  '#84cc16', '#f43f5e', '#78716c',
+];
+
 interface AddHouseDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -32,6 +38,7 @@ export function AddHouseDialog({
 }: AddHouseDialogProps): React.JSX.Element {
   const [name, setName] = useState<string>('');
   const [code, setCode] = useState<string>('');
+  const [color, setColor] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const addHouse = useMutation(api.houses.addHouse);
@@ -56,6 +63,7 @@ export function AddHouseDialog({
         schoolId,
         name: name.trim(),
         code: code.trim(),
+        color: color && /^#[0-9A-Fa-f]{6}$/.test(color) ? color : undefined,
         createdBy,
       });
 
@@ -63,6 +71,7 @@ export function AddHouseDialog({
       onOpenChange(false);
       setName('');
       setCode('');
+      setColor('');
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Failed to add house');
       console.error(error);
@@ -101,6 +110,37 @@ export function AddHouseDialog({
               maxLength={6}
               required
             />
+          </div>
+          <div className="space-y-2">
+            <Label>Color (optional)</Label>
+            <div className="flex flex-wrap gap-2">
+              {PRESET_COLORS.map((hex) => (
+                <button
+                  key={hex}
+                  type="button"
+                  aria-label={`Color ${hex}`}
+                  className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 ${color === hex ? 'border-foreground ring-2 ring-offset-2 ring-offset-background' : 'border-transparent'}`}
+                  style={{ backgroundColor: hex }}
+                  onClick={() => setColor(hex)}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-2 mt-2">
+              <input
+                type="color"
+                id="house-color-custom"
+                value={color && /^#[0-9A-Fa-f]{6}$/.test(color) ? color : '#3b82f6'}
+                onChange={(e) => setColor(e.target.value)}
+                className="h-9 w-9 cursor-pointer rounded border border-input bg-transparent p-0"
+              />
+              <Input
+                placeholder="#3b82f6"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="w-24 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
           </div>
           <DialogFooter>
             <Button

--- a/src/components/houses/edit-house-dialog.tsx
+++ b/src/components/houses/edit-house-dialog.tsx
@@ -18,11 +18,18 @@ import { Label } from '@/components/ui/label';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 
+const PRESET_COLORS = [
+  '#ef4444', '#f97316', '#eab308', '#22c55e', '#14b8a6',
+  '#3b82f6', '#8b5cf6', '#ec4899', '#6366f1', '#0ea5e9',
+  '#84cc16', '#f43f5e', '#78716c',
+];
+
 interface House {
   _id: Id<'houses'>;
   schoolId: string;
   name: string;
   code: string;
+  color?: string;
   sortOrder?: number;
 }
 
@@ -41,6 +48,7 @@ export function EditHouseDialog({
 }: EditHouseDialogProps): React.JSX.Element {
   const [name, setName] = useState<string>('');
   const [code, setCode] = useState<string>('');
+  const [color, setColor] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const updateHouse = useMutation(api.houses.updateHouse);
@@ -49,6 +57,7 @@ export function EditHouseDialog({
     if (house) {
       setName(house.name);
       setCode(house.code);
+      setColor(house.color || '');
     }
   }, [house]);
 
@@ -74,6 +83,7 @@ export function EditHouseDialog({
         houseId: house._id,
         name: name.trim(),
         code: code.trim(),
+        color: color && /^#[0-9A-Fa-f]{6}$/.test(color) ? color : undefined,
         updatedBy,
       });
 
@@ -117,6 +127,37 @@ export function EditHouseDialog({
               maxLength={6}
               required
             />
+          </div>
+          <div className="space-y-2">
+            <Label>Color (optional)</Label>
+            <div className="flex flex-wrap gap-2">
+              {PRESET_COLORS.map((hex) => (
+                <button
+                  key={hex}
+                  type="button"
+                  aria-label={`Color ${hex}`}
+                  className={`h-8 w-8 rounded-full border-2 transition-transform hover:scale-110 ${color === hex ? 'border-foreground ring-2 ring-offset-2 ring-offset-background' : 'border-transparent'}`}
+                  style={{ backgroundColor: hex }}
+                  onClick={() => setColor(hex)}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-2 mt-2">
+              <input
+                type="color"
+                id="house-color-custom-edit"
+                value={color && /^#[0-9A-Fa-f]{6}$/.test(color) ? color : '#3b82f6'}
+                onChange={(e) => setColor(e.target.value)}
+                className="h-9 w-9 cursor-pointer rounded border border-input bg-transparent p-0"
+              />
+              <Input
+                placeholder="#3b82f6"
+                value={color}
+                onChange={(e) => setColor(e.target.value)}
+                className="w-24 font-mono text-sm"
+                maxLength={7}
+              />
+            </div>
           </div>
           <DialogFooter>
             <Button

--- a/src/components/students/add-student-dialog.tsx
+++ b/src/components/students/add-student-dialog.tsx
@@ -848,7 +848,15 @@ export function AddStudentDialog({ open, onOpenChange }: AddStudentDialogProps):
                       <SelectItem value="none">None</SelectItem>
                       {houses?.map((house) => (
                         <SelectItem key={house._id} value={house._id}>
-                          {house.name} ({house.code})
+                          <span className="flex items-center gap-2">
+                            {house.color && (
+                              <span
+                                className="h-3 w-3 shrink-0 rounded-full border border-border"
+                                style={{ backgroundColor: house.color }}
+                              />
+                            )}
+                            {house.name} ({house.code})
+                          </span>
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/src/components/students/edit-student-dialog.tsx
+++ b/src/components/students/edit-student-dialog.tsx
@@ -670,7 +670,15 @@ export function EditStudentDialog({ student, open, onOpenChange }: EditStudentDi
                       <SelectItem value="none">None</SelectItem>
                       {houses?.map((h) => (
                         <SelectItem key={h._id} value={h._id}>
-                          {h.name} ({h.code})
+                          <span className="flex items-center gap-2">
+                            {h.color && (
+                              <span
+                                className="h-3 w-3 shrink-0 rounded-full border border-border"
+                                style={{ backgroundColor: h.color }}
+                              />
+                            )}
+                            {h.name} ({h.code})
+                          </span>
                         </SelectItem>
                       ))}
                     </SelectContent>

--- a/src/components/teachers/add-teacher-dialog.tsx
+++ b/src/components/teachers/add-teacher-dialog.tsx
@@ -792,7 +792,15 @@ export function AddTeacherDialog({
                         <SelectItem value="none">None</SelectItem>
                         {houses?.map((house) => (
                           <SelectItem key={house._id} value={house._id}>
-                            {house.name} ({house.code})
+                            <span className="flex items-center gap-2">
+                              {house.color && (
+                                <span
+                                  className="h-3 w-3 shrink-0 rounded-full border border-border"
+                                  style={{ backgroundColor: house.color }}
+                                />
+                              )}
+                              {house.name} ({house.code})
+                            </span>
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/src/components/teachers/edit-teacher-dialog.tsx
+++ b/src/components/teachers/edit-teacher-dialog.tsx
@@ -480,7 +480,15 @@ export function EditTeacherDialog({
                     <SelectItem value="none">None</SelectItem>
                     {houses?.map((house) => (
                       <SelectItem key={house._id} value={house._id}>
-                        {house.name} ({house.code})
+                        <span className="flex items-center gap-2">
+                          {house.color && (
+                            <span
+                              className="h-3 w-3 shrink-0 rounded-full border border-border"
+                              style={{ backgroundColor: house.color }}
+                            />
+                          )}
+                          {house.name} ({house.code})
+                        </span>
                       </SelectItem>
                     ))}
                   </SelectContent>


### PR DESCRIPTION
- Introduced an optional color field for houses in the schema, allowing users to specify a hex color code.
- Updated the add and edit house dialogs to include color selection options, enhancing user experience with preset colors and a color picker.
- Modified house display components to show the selected color alongside house names and codes, improving visual organization.
- Enhanced student and teacher dialogs to reflect house colors, providing a more intuitive interface for house selection.